### PR TITLE
Added support for ADE9178 Evaluation board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,80 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(board_support C)
+
+add_library(board_support INTERFACE)
+
+# Enable CMake support for ASM and C languages
+enable_language(C ASM)
+
+set(BSP_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+option(USE_FREERTOS "CompileFreeRTOS sources" OFF)
+option(ZEPHYR_BUILD "Build app with Zephyr" OFF)
+option(USE_IIO "Compile IIO board_support sources" OFF)
+
+## Add project symbols (macros)
+if(BUILD_TARGET MATCHES "stm32h573zi")
+	target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
+		STM32H573xx
+		$<$<CONFIG:Debug>:DEBUG>
+	)
+elseif(BUILD_TARGET MATCHES "stm32h735ig")
+	target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
+		STM32H735xx
+		$<$<CONFIG:Debug>:DEBUG>
+	)
+endif()
+
+#Needed to print variables in cmake
+include(CMakePrintHelpers)
+
+if(BUILD_TARGET MATCHES "stm32h573zi")
+	add_subdirectory(${BSP_ROOT_DIR}/stm/crane_app_mcu
+		 			 ${CMAKE_BINARY_DIR}/stm32h573zi)
+	target_link_libraries(board_support INTERFACE stm32h573zi)
+elseif(BUILD_TARGET MATCHES "stm32h735ig")
+	add_subdirectory(${BSP_ROOT_DIR}/stm/h7_mcu_board
+		 			 ${CMAKE_BINARY_DIR}/stm32h735ig)
+	target_link_libraries(board_support INTERFACE stm32h735ig)
+elseif(BUILD_TARGET MATCHES "stm32h563zi")
+	add_subdirectory(${BSP_ROOT_DIR}/stm/nucleo_h563zi_master
+		 			 ${CMAKE_BINARY_DIR}/stm32h563zi)
+	target_link_libraries(board_support INTERFACE stm32h563zi)
+elseif(BUILD_TARGET MATCHES "max32670")
+	add_subdirectory(${BSP_ROOT_DIR}/max/eval_ade9178
+		 			 ${CMAKE_BINARY_DIR}/max32670)
+	target_link_libraries(board_support INTERFACE max32670)
+else()
+	add_subdirectory(${BSP_ROOT_DIR}/stm/nucleo_h563zi_master
+		 			 ${CMAKE_BINARY_DIR}/stm32h563zi)
+	target_link_libraries(board_support INTERFACE stm32h563zi)
+endif()
+
+if(USE_FREERTOS)
+	add_subdirectory(${BSP_ROOT_DIR}/rtos)
+	target_link_libraries(board_support INTERFACE rtos)
+	set(GENERIC_SRC ${BSP_ROOT_DIR}/rtos/source/evb_freertos.c)
+	set(RTOS_INCLUDE ${BSP_ROOT_DIR}/rtos/include)
+elseif(ZEPHYR_BUILD)
+	set(GENERIC_SRC ${BSP_ROOT_DIR}/stm/nucleo_h563zi_master/source/zephyr_delay.c)
+else()
+	set(GENERIRTOS_INCLUDEC_INCLUDE "")
+	if(BUILD_TARGET MATCHES "stm32h563zi" OR BUILD_TARGET MATCHES "stm32h573zi" OR BUILD_TARGET MATCHES "stm32h735ig")
+		set(GENERIC_SRC ${BSP_ROOT_DIR}/stm/source/stm_delay.c)
+	endif()
+endif()
+
+target_include_directories(board_support INTERFACE
+			${BSP_ROOT_DIR}/generic/include
+			${RTOS_INCLUDE}
+)
+
+message("Just a bunch of debug statements:")
+cmake_print_variables(USE_IIO)
+cmake_print_variables(BUILD_TARGET)
+cmake_print_variables(GENERIC_SRC)
+target_sources(board_support INTERFACE
+	${GENERIC_SRC}
+	${BSP_ROOT_DIR}/generic/source/message.c
+)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# energy-board-support
-energy-board-support
+# Energy Board Support
+
+This repository contains files to abstract the board details and MCU drivers used for the application. This includes functions to initialize the board and configure required peripherals such as SPI. Refer to the header files in the [include](generic/include/) folder for prototypes of functions implemented by this module.
+
+Note that these codes use HALs and MCU drivers provided by MCU vendors beneath the API layer. This expects appropriate drivers to be included as part of the application. The intention is to facilitate easy development of examples targeting multiple boards. For normal application development targeted only to one MCU, it would be more efficient to directly use the APIs provided by the MCU vendor.
+
+Repository structure:
+
+```
+<mcu_family>/include         - Common include files for boards with <mcu_family>
+<mcu_family>/source          - Common source files for boards with <mcu_family>
+<mcu_family>/<board_name>    - Board-specific includes and sources
+<dummy_board>                - Dummy implementation without hardware dependencies
+```

--- a/cmake/gcc-arm-none-eabi.cmake
+++ b/cmake/gcc-arm-none-eabi.cmake
@@ -1,0 +1,40 @@
+set(CMAKE_SYSTEM_NAME               Generic)
+set(CMAKE_SYSTEM_PROCESSOR          arm)
+
+set(CMAKE_C_COMPILER_FORCED TRUE)
+set(CMAKE_CXX_COMPILER_FORCED TRUE)
+set(CMAKE_C_COMPILER_ID GNU)
+set(CMAKE_CXX_COMPILER_ID GNU)
+
+
+# Set compilers
+set(CMAKE_C_COMPILER "${TOOLCHAIN_PREFIX}gcc.exe")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_PREFIX}gcc.exe")
+set(CMAKE_CXX_COMPILER "${TOOLCHAIN_PREFIX}g++.exe")
+set(CMAKE_LINKER "${TOOLCHAIN_PREFIX}ld.exe")
+set(CMAKE_OBJCOPY "${TOOLCHAIN_PREFIX}objcopy.exe")
+set(CMAKE_SIZE "${TOOLCHAIN_PREFIX}size.exe")
+
+set(CMAKE_EXECUTABLE_SUFFIX_ASM     ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_C       ".elf")
+set(CMAKE_EXECUTABLE_SUFFIX_CXX     ".elf")
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic -fdata-sections -ffunction-sections")
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g3")
+endif()
+if(CMAKE_BUILD_TYPE MATCHES Release)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g0")
+endif()
+
+set(CMAKE_ASM_FLAGS "${CMAKE_C_FLAGS} -x assembler-with-cpp -MMD -MP")
+set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-statics")
+
+
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,-Map=${CMAKE_PROJECT_NAME}.map -Wl,--gc-sections")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lc -lm -Wl,--end-group")
+set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--print-memory-usage")
+
+set(CMAKE_CXX_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -Wl,--start-group -lstdc++ -lsupc++ -Wl,--end-group")

--- a/dummy_board/adi_evb.c
+++ b/dummy_board/adi_evb.c
@@ -1,0 +1,137 @@
+/******************************************************************************
+ Copyright (c) 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     adi_evb.c
+ * @brief    Template file for ADC Service board dependencies.
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+#include "adi_evb.h"
+#include <stdint.h>
+
+/*=============  C O D E  =============*/
+
+int32_t EvbInit(void **phEvb, ADI_EVB_CONFIG *pConfig)
+{
+    /*
+        Initialize SPI connected to ADC in mode 3
+        Setup ISR to  pConfig->spiConfig.pfAdeSpiRxCallback on SPI RX completion
+
+        Initialize GPIO connected to DREADY pin of ADC as input
+        Enable interrupt for GPIO on falling edge
+        Call pConfig->gpioConfig.pfGpioCallback from the ISR
+    */
+    (void)phEvb;   /* Dummy use of argument */
+    (void)pConfig; /* Dummy use of argument */
+
+    return 0;
+}
+
+int32_t EvbResetAdcs(void)
+{
+    /* Toggle pin connected to the reset pin of ADC*/
+    return 0;
+}
+
+int32_t EvbStartAdeSpiTx(void *hEvb, uint8_t *pData, uint32_t numBytes)
+{
+    (void)hEvb;     /* Dummy use of argument */
+    (void)pData;    /* Dummy use of argument */
+    (void)numBytes; /* Dummy use of argument */
+
+    return 0;
+}
+
+int32_t EvbResetAde(void)
+{
+    /* Toggle pin connected to the reset pin of ADC and ADE9178*/
+    return 0;
+}
+
+int32_t EvbStartAdeSpiRx(void *hEvb, uint8_t *pData, uint32_t numBytes)
+{
+    (void)hEvb;     /* Dummy use of argument */
+    (void)pData;    /* Dummy use of argument */
+    (void)numBytes; /* Dummy use of argument */
+
+    return 0;
+}
+
+int32_t EvbStartAdeSpiTxRx(void *hEvb, uint8_t *pTxData, uint8_t *pRxData, uint32_t numBytes,
+                           uint32_t timeOutCount)
+{
+    (void)hEvb;         /* Dummy use of argument */
+    (void)pTxData;      /* Dummy use of argument */
+    (void)pRxData;      /* Dummy use of argument */
+    (void)numBytes;     /* Dummy use of argument */
+    (void)timeOutCount; /* Dummy use of argument */
+
+    return 0;
+}
+
+int32_t EvbLedOn(uint32_t idx)
+{
+    (void)idx; /* Dummy use of argument */
+
+    /* For error indication*/
+    return 0;
+}
+
+int32_t EvbDelayMs(uint32_t delayMs)
+{
+    (void)delayMs; /* Dummy use of argument */
+
+    return 0;
+}
+
+int32_t EvbStartHostUartTx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    /* Not needed for ADC service.
+    Only to transfer data to host*/
+    (void)hEvb;     /* Dummy use of argument */
+    (void)pBuffer;  /* Dummy use of argument */
+    (void)numBytes; /* Dummy use of argument */
+
+    return 0;
+}
+
+void EvbEnableAllGPIOIrq()
+{
+    /* Enable all GPIO interrupts */
+    // This function should enable all GPIO interrupts as per the board design.
+    // Implementation depends on the specific hardware and GPIO library used.
+}
+
+uint32_t EvbGetTime()
+{
+    return 0;
+}
+
+int32_t EvbGetPinState(uint32_t port, uint32_t flag)
+{
+    (void)port; /* Dummy use of argument */
+    (void)flag; /* Dummy use of argument */
+
+    return 0;
+}
+
+int32_t EvbSetAdeWfsUartBaudrate(void *hEvb, uint32_t baudRate)
+{
+    (void)hEvb;     /* Dummy use of argument */
+    (void)baudRate; /* Dummy use of argument */
+    return 0;
+}
+int32_t EvbStartAdeWfsUartRx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    (void)hEvb;     /* Dummy use of argument */
+    (void)pBuffer;  /* Dummy use of argument */
+    (void)numBytes; /* Dummy use of argument */
+    return 0;
+}
+
+/**
+ * @}
+ */

--- a/dummy_board/config/board_cfg.h
+++ b/dummy_board/config/board_cfg.h
@@ -1,0 +1,80 @@
+/******************************************************************************
+ Copyright (c) 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file        board_cfg.h
+ * @brief       configuration file for ADE9178 eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __BOARD_CFG_H__
+#define __BOARD_CFG_H__
+
+/*============= I N C L U D E S =============*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/** Port for HOST_RDY and HOST_ERR pins  */
+#define BOARD_CFG_ADECOMM_PORT 0
+/** Port for IRQ pins  */
+#define BOARD_CFG_ADEIRQ_PORT 0
+/** Number of port 0 GPIOs */
+#define BOARD_CFG_NUM_PORT0_GPIOS 8
+/** dummy macro */
+#define BOARD_CFG_MB85RS_PRODUCT_ID 0
+/** Pin - HOST_RDY */
+#define BOARD_CFG_HOST_RDY_PIN 0
+/** Pin - HOST_ERR */
+#define BOARD_CFG_HOST_ERR_PIN 0
+/**  Pin  -IRQ0*/
+#define BOARD_CFG_IRQ0_PIN 0
+/**  Pin -  IRQ1 */
+#define BOARD_CFG_IRQ1_PIN 0
+/**  Pin - IRQ2 */
+#define BOARD_CFG_IRQ2_PIN 0
+/**  Pin - IRQ3 */
+#define BOARD_CFG_IRQ3_PIN 0
+/**  Pin - CF1 */
+#define BOARD_CFG_CF1_PIN 0
+/**  Pin - CF2 */
+#define BOARD_CFG_CF2_PIN 0
+/**  Pin - HOST_CS */
+#define BOARD_CFG_SS_PIN 0
+/** ADE9178 SPI */
+#define BOARD_CFG_ADE9178_SPI 0
+/** ADE9178 WFS UART */
+#define BOARD_CFG_WFS_UART 0
+/** ADE9178 Host UART */
+#define BOARD_CFG_HOST_UART 0
+/** Number of SPI0 slaves  */
+#define BOARD_CFG_ADE9178_SPI_NUM_SLAVES 1
+/** Slave index */
+#define BOARD_CFG_ADE9178_SS_INDEX 0
+/**  Pin -  ADC reset */
+#define BOARD_CFG_ADC_RESET_PIN 0
+/**  Pin -  ADE reset */
+#define BOARD_CFG_ADE_RESET_PIN 0
+/**  Pin -  led */
+#define BOARD_CFG_LED1_PIN 0
+/**  Pin -  led */
+#define BOARD_CFG_LED2_PIN 0
+/**  Reset type either for EVB or EVK */
+#define BOARD_CFG_RESET_TYPE 0
+/**  Timer  clock type */
+#define BOARD_CFG_SYSTEM_TIMER_CLOCK_TYPE 0
+/**  Timer */
+#define BOARD_CFG_SYSTEM_TIMER 0
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARD_CFG_H__ */
+
+/** @} */

--- a/generic/include/adi_evb.h
+++ b/generic/include/adi_evb.h
@@ -1,0 +1,217 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+/**
+ * @file        adi_evb.h
+ * @brief       SPI APIs for ADE9178 Eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_H__
+#define __ADI_EVB_H__
+
+/*============= I N C L U D E S =============*/
+
+#ifdef USE_CRC
+#include "adi_evb_crc.h"
+#endif
+
+#include "adi_evb_gpio.h"
+#include "adi_evb_i2c.h"
+#include "adi_evb_spi.h"
+#include "adi_evb_timer.h"
+#include "adi_evb_uart.h"
+#include "board_cfg.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/** Macro to denote NULL handle */
+#define ADI_EVB_STATUS_NULL_HANDLE -1
+/** Macro to denote success  */
+#define ADI_EVB_STATUS_SUCCESS 0
+/** Macro to denote  spi init error*/
+#define ADI_EVB_STATUS_SPI_INIT_ERROR 1
+/** Macro to denote uart init error in waveform streaming  */
+#define ADI_EVB_STATUS_WFRM_UART_INIT_ERROR 2
+/** Macro to denote uart init error  */
+#define ADI_EVB_STATUS_HOST_UART_INIT_ERROR 3
+/** Macro to denote gpio init error  */
+#define ADI_EVB_STATUS_GPIO_INIT_ERROR 4
+/** Error in acquiring DMA channel */
+#define ADI_EVB_STATUS_DMA_CHANNEL_ACQUIRE_ERROR 5
+/** Invlaid LED index */
+#define ADI_EVB_STATUS_INVALID_INDEX 7
+/** General  falure */
+#define ADI_EVB_STATUS_INIT_FAILURE 8
+
+/** Typedef for callbacks from EVB */
+typedef void (*ADI_EVB_CALLBACK)(void);
+/** Typedef for callbacks from EVB */
+typedef void (*ADI_EVB_GPIO_CALLBACK)(uint32_t port, uint32_t flag);
+/** Typedef for EVB status */
+typedef int32_t ADI_EVB_STATUS;
+
+/**
+ * @brief Non-build time configuration for UART
+ *  Use app_cfg.h for build time configuration
+ */
+typedef struct
+{
+    /** Wfs rx callback */
+    ADI_EVB_CALLBACK pfWfsUartRxCallback;
+    /** Host Wfs rx callback */
+    ADI_EVB_CALLBACK pfHostUartRxCallback;
+    /** Host Wfs tx callback */
+    ADI_EVB_CALLBACK pfHostUartTxCallback;
+} ADI_EVB_UART_CONFIG;
+
+/**
+ * @brief Non-build time configuration for SPI
+ *  Use app_cfg.h for build time configuration
+ */
+typedef struct
+{
+    /** Spi rx callback */
+    ADI_EVB_CALLBACK pfAdeSpiRxCallback;
+    /** Spi tx callback */
+    ADI_EVB_CALLBACK pfAdeSpiTxCallback;
+    /** Spi rx callback */
+    ADI_EVB_CALLBACK pfHostSpiRxCallback;
+    /** Spi tx callback */
+    ADI_EVB_CALLBACK pfHostSpiTxCallback;
+    /** Spi rx callback */
+    ADI_EVB_CALLBACK pfFramSpiRxCallback;
+    /** Spi tx callback */
+    ADI_EVB_CALLBACK pfFramSpiTxCallback;
+} ADI_EVB_SPI_CONFIG;
+
+/**
+ * @brief Non-build time configuration for GPIOs
+ *  Use app_cfg.h for build time configuration
+ */
+typedef struct
+{
+    /** uart config */
+    ADI_EVB_GPIO_CALLBACK pfGpioCallback;
+} ADI_EVB_GPIO_CONFIG;
+
+/**
+ * @brief Top level configuration structure
+ *
+ */
+typedef struct
+{
+    /** uart config */
+    ADI_EVB_UART_CONFIG uartConfig;
+    /** spi config */
+    ADI_EVB_SPI_CONFIG spiConfig;
+    /** gpio config */
+    ADI_EVB_GPIO_CONFIG gpioConfig;
+
+} ADI_EVB_CONFIG;
+
+/**
+ * @brief EVB private data holder
+ * Do not access this structure from application
+ */
+typedef struct
+{
+    /** user spi handle */
+    void *hSpi;
+    /** user uart handle */
+    void *hUart;
+    /** user gpio handle */
+    void *hGpio;
+    /** board config */
+    ADI_EVB_CONFIG config;
+
+} ADI_EVB_INFO;
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+
+/**
+ * @brief       Delays execution by the specified number of milliseconds.
+ * @param[in]   delayMs     Delay duration in ms.
+ * @return      ADI_EVB_STATUS_SUCCESS on success. Refer to #ADI_EVB_STATUS for other return codes.
+ */
+ADI_EVB_STATUS EvbDelayMs(uint32_t delayMs);
+
+/**
+ * @brief Initialzes peripherals. Refer to board_cfg.h for
+ * static board configurations. USe app_cfg.h for application
+ * specific configurations
+ * @param phEvb  - Pointer to store EVB handle
+ * @param pConfig - Pointer configuration structure. This can be NULL if
+ * there is nothing configure
+ * @return int32_t
+ */
+int32_t EvbInit(void **phEvb, ADI_EVB_CONFIG *pConfig);
+
+/**
+ * @brief Initialises UART
+ * @param[out] phUart - Pointer to store handle
+ * @param[in] pConfig - Pointer configuration structure. This can be NULL if
+ * there is nothing configure
+
+ * @return  error or success
+ */
+int32_t EvbInitUart(void **phUart, ADI_EVB_UART_CONFIG *pConfig);
+
+/**
+ * @brief Initialises Gpios of a board
+ * @param[out] phGpio - Pointer to store handle
+ * @param pConfig - Pointer configuration structure. This can be NULL if
+ * there is nothing configure
+ * @return  error or success
+ */
+int32_t EvbInitGpio(void **phGpio, ADI_EVB_GPIO_CONFIG *pConfig);
+
+/**
+ * @brief Initialises SPI of a board
+ * @param[out] phSpi - Pointer to store handle
+ * @param pConfig - Pointer configuration structure. This can be NULL if
+ * there is nothing configure
+ * @return  error or success
+ */
+int32_t EvbInitAdeSpi(void **phSpi, ADI_EVB_SPI_CONFIG *pConfig);
+
+/**
+ * @brief Initialises SPI of a board
+ * @param[out] phSpi - Pointer to store handle
+ * @param pConfig - Pointer configuration structure. This can be NULL if
+ * there is nothing configure
+ * @return  error or success
+ */
+int32_t EvbInitSpi(void **phSpi, ADI_EVB_SPI_CONFIG *pConfig);
+
+/**
+ * @brief Initialize timer
+ * @return 0 -  success
+ */
+uint32_t EvbTimerInit(void);
+
+/**
+ * @brief Initialize timer
+ * @return 0 -  success
+ */
+uint32_t EvbLowPowerTimerInit(void);
+/**
+ * @brief Function to reset EVB
+ * @return 0 -  success
+ */
+int32_t EvbInitReset(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_H__ */
+
+/** @} */

--- a/generic/include/adi_evb_crc.h
+++ b/generic/include/adi_evb_crc.h
@@ -1,0 +1,72 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file  adi_evb_crc.h
+ * @brief CRC API header file
+ * @addtogroup    CRC drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_CRC_H__
+#define __ADI_EVB_CRC_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============= I N C L U D E S =============*/
+#include "adi_crc.h"
+#include <stdint.h>
+
+/**
+ * @brief       Initialise uart
+ * @param[in]   phCrc -  Pointer to uart instance struct
+ * @return      status
+ */
+ADI_CRC_RESULT EvbInitCrc(void **phCrc);
+
+/**
+ * @brief       Set crc config
+ * @param[in]   pData -  Pointer to crc data struct
+ * @return      status
+ */
+int32_t EvbCrcSetConfig(ADI_CRC_DATA *pData);
+
+/**
+ * @brief       Calculate Crc
+ * @param[in]   pCrcData -  Pointer to crc data struct
+ * @param[in]   pData -  Pointer to data for which crc must be calculated
+ * @param[in]   offset -  offset value
+ * @param[in]   numBytes -  num of data bytes
+ */
+void EvbCalculateCrc(ADI_CRC_DATA *pCrcData, uint8_t *pData, uint16_t offset, uint32_t numBytes);
+
+/**
+ * @brief       Set crc config
+ * @param[in]   hCrc -  Crc handle
+ * @param[in]   pData -  Pointer to crc value
+ * @return      status
+ */
+ADI_CRC_RESULT EvbGetCrc(ADI_CRC_HANDLE hCrc, uint32_t *pData);
+
+/**
+ * @brief       Clear crc interrupt
+ */
+void EvbCrcClearInterrupt(void);
+
+/**
+ * @brief       Reset Crc module
+ */
+void EvbResetHw(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_CRC_H__ */
+
+/**
+ * @}
+ */

--- a/generic/include/adi_evb_gpio.h
+++ b/generic/include/adi_evb_gpio.h
@@ -1,0 +1,125 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+/**
+ * @file        adi_evb_gpio.h
+ * @brief       SPI APIs for ADE9178 Eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_GPIO_H__
+#define __ADI_EVB_GPIO_H__
+
+/*============= I N C L U D E S =============*/
+
+#include "board_cfg.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+
+/**
+ * @brief       Resets the ADE.
+ * @return      int32_t_SUCCESS on success.
+ */
+int32_t EvbResetAde(void);
+
+/**
+ * @brief       Resets the ADCs.
+ * @return      int32_t_SUCCESS on success.
+ */
+int32_t EvbResetAdcs(void);
+
+/**
+ * @brief       Resets all devices.
+ * @details     ADCs are reset before ADE9178.
+ * @return      int32_t_SUCCESS on success.
+ */
+int32_t EvbResetAll(void);
+
+/**
+ *  @brief      Flashes an LED.
+ *  @param[in]  idx         Index of the LED to flash.
+ *  @param[in]  numFlashes  Number of times to flash the LED.
+ *  @param[in]  flashMs     Duration in ms for which the LED will be on.
+ *  @details    The LED will flash with a 50% duty cycle.
+ *  @return     int32_t_SUCCESS on success.
+ */
+int32_t EvbLedFlash(uint32_t idx, uint32_t numFlashes, uint32_t flashMs);
+
+/**
+ *  @brief      Turns on an LED.
+ *  @param[in]  idx         Index of the LED to turn on.
+ *  @return     int32_t_SUCCESS on success.
+ */
+int32_t EvbLedOn(uint32_t idx);
+
+/**
+ *  @brief      Configures Adc Stand by mode.
+ *  @param[in]  mode 1:Exit Stand By  0:Enter Stand By
+ *  @return     int32_t_SUCCESS on success.
+ */
+int32_t EvbSetStandby(uint8_t mode);
+/**
+ *  @brief      Turns off an LED.
+ *  @param[in]  idx         Index of the LED to turn off.
+ *  @return     int32_t_SUCCESS on success.
+ */
+int32_t EvbLedOff(uint32_t idx);
+
+/**
+ * Enable GPIO Irq
+ * @param port - Port of the GPIO
+ * @param pin - Pin for the GPIO
+ */
+void EvbEnableGPIOIrq(uint32_t port, uint32_t pin);
+
+/**
+ * Disable GPIO Irq
+ * @param port - Port of the GPIO
+ * @param pin - Pin for the GPIO
+ */
+void EvbDisableGPIOIrq(uint32_t port, uint32_t pin);
+
+/**
+ * Enable/Disable DREADY Irq
+ * @param enable - 1 to enable and 0 to disable
+ */
+int32_t EvbEnableDreadyIrq(uint8_t enable);
+
+/**
+ * @brief Function to handle GPIO IRQ.
+ */
+void EvbEnableAllGPIOIrq(void);
+/**
+ * @brief Function to perform hardware reset of the ADC.
+ */
+void EvbAdcReset(void);
+
+/**
+ * @brief Function to delay for a specified time in milliseconds.
+ * @param delayMsec - Time to delay in milliseconds.
+ */
+void OsalDelay(int32_t delayMsec);
+
+/**
+ * Get the pinstate
+ * @param port - Port of the GPIO
+ * @param flag - mask of the GPIO
+ */
+int32_t EvbGetPinState(uint32_t port, uint32_t flag);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_GPIO_H__ */
+
+/** @} */

--- a/generic/include/adi_evb_i2c.h
+++ b/generic/include/adi_evb_i2c.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ Copyright (c) 2025  Analog Devices Inc.
+******************************************************************************/
+/**
+ * @file        adi_evb_i2c.h
+ * @brief       I2C APIs for different EVKs
+ * @addtogroup  I2C drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_I2C_H__
+#define __ADI_EVB_I2C_H__
+
+/*============= I N C L U D E S =============*/
+
+#include "board_cfg.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/**
+ * @brief I2C API for EVKs
+ *
+ * @return  error or success
+ */
+uint32_t EvbInitI2C(void);
+
+/**
+ * @brief Transmits data to an I2C device.
+ *
+ * This function sends data to a specified I2C device using its device address.
+ *
+ * @param[in] devAddr The 7-bit I2C device address.
+ * @param[in] pData Pointer to the data buffer to be written.
+ * @param[in] len The number of bytes to write from the data buffer.
+ *
+ * @return A 32-bit status code indicating the result of the operation.
+ *         Typically, 0 indicates success, while non-zero values indicate errors.
+ */
+uint32_t EvbTransmitI2C(uint8_t *pData, uint16_t devAddr, uint16_t len);
+
+/**
+ * @brief Receives data from an I2C device.
+ *
+ * This function reads data from a specified I2C device using its device address.
+ *
+ * @param[in]  devAddr The 7-bit I2C device address.
+ * @param[out] pData Pointer to the buffer where the read data will be stored.
+ * @param[in]  len The number of bytes to read into the buffer.
+ *
+ * @return A 32-bit status code indicating the result of the operation.
+ *         Typically, 0 indicates success, while non-zero values indicate errors.
+ */
+uint32_t EvbReceiveI2C(uint8_t *pData, uint16_t devAddr, uint16_t len);
+
+/**
+ * @brief Interrupt Handler
+ */
+void EvbHandlerI2CTx(void);
+
+/**
+ * @brief Interrupt Handler
+ * @return Pointer to I2C Transmit Completion Flag
+ */
+volatile uint8_t *EvbGetTxFlag(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_I2C_H__ */
+
+/** @} */

--- a/generic/include/adi_evb_spi.h
+++ b/generic/include/adi_evb_spi.h
@@ -1,0 +1,186 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+/**
+ * @file        adi_evb_spi.h
+ * @brief       SPI APIs for ADE9178 Eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_SPI_H__
+#define __ADI_EVB_SPI_H__
+
+/*============= I N C L U D E S =============*/
+
+#include "board_cfg.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+
+/**
+ * @brief SPI Tx API for ADE9178 Eval board
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pData  - pointer to the data to be sent
+ * @param[in]  numBytes  - num of bytes to send
+ *
+ * @return  error or success
+ */
+int32_t EvbStartAdeSpiTx(void *hEvb, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief SPI Rx API for ADE9178 Eval board
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pData  - pointer to the data to be received
+ * @param[in]  numBytes  - num of bytes to receive
+ * @return  error or success
+ */
+int32_t EvbStartAdeSpiRx(void *hEvb, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief SPI Rx API for ADE9178 Eval board
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pTxData  - pointer to the data to be received
+ * @param[in]  pRxData  - pointer to the data to be received
+ * @param[in]  numBytes  - num of bytes to receive
+ * @return  error or success
+ */
+
+int32_t EvbStartAdeSpiTxRxAsync(void *hEvb, uint8_t *pTxData, uint8_t *pRxData, uint32_t numBytes);
+
+/**
+ * @brief Start SPI TxRx in blocking mode. This function will block until the transfer is
+ * complete.
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pTxData  - pointer to the data to be received
+ * @param[in]  pRxData  - pointer to the data to be received
+ * @param[in]  numBytes  - num of bytes to receive
+ * @param[in]  timeOutCount  - timeout count to wait in a blocking state.
+ * @return  error or success
+ */
+int32_t EvbStartAdeSpiTxRx(void *hEvb, uint8_t *pTxData, uint8_t *pRxData, uint32_t numBytes,
+                           uint32_t timeOutCount);
+
+/**
+ * @brief Start SPI TXRx in blocking mode. This function will block until the transfer is complete.
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pTxData  - pointer to the data to be received
+ * @param[in]  pRxData  - pointer to the data to be received
+ * @param[in]  numBytes  - num of bytes to receive
+ * @param[in]  timeOutCount  - timeout count to wait in a blocking state.
+ * @return  error or success
+ */
+int32_t EvbStartFramSpiTxRx(void *hEvb, uint8_t *pTxData, uint8_t *pRxData, uint32_t numBytes,
+                            uint32_t timeOutCount);
+
+/**
+ * @brief Sets SPI frequency
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  spiFrequency  - frequency in Hz
+ * @return  success or error
+ */
+int32_t EvbSetAdeSpiFrequency(void *hEvb, uint32_t spiFrequency);
+
+/**
+ * @brief Start Spi tx
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in] pData  - Pointer to data to transmit
+ * @param[in] numBytes - num of bytes
+ * @return status
+ */
+int32_t EvbStartHostSpiRx(void *hEvb, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief Start Spi tx
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in] pData  - Pointer to data to transmit
+ * @param[in] numBytes - num of bytes
+ * @return status
+ */
+int32_t EvbStartHostSpiTx(void *hEvb, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief Abort spi
+ * @return status
+ */
+int32_t EvbAbortHostSpi(void);
+
+/* Following shall be implemented by the applications*/
+/**
+ * @brief Host Spi Callback
+ * @param[in] aborted  - aborted flag
+ */
+void EvbHostSpiIrqCallback(uint8_t aborted);
+
+/**
+ * @brief Tx dma Callback
+ */
+void EvbHostSpiTxIrqCallback(void);
+
+/**
+ * @brief Rx dma Callback
+ */
+void EvbHostSpiRxIrqCallback(void);
+
+/**
+ * @brief Sets SPI freq
+ * @param[in] hEvb - pointer to board handle
+ * @param[in] spiFrequency - one of the possible baudrate prescaler values
+ * @return 0 -  success
+ */
+int32_t EvbSetAdcSpiFrequency(void *hEvb, uint32_t spiFrequency);
+
+/**
+ * @brief Clears SPI Interrupt
+ * @param[in] hUser - pointer to user handle
+ */
+void EvbAdcClearSpiInterrupt(void *hUser);
+
+/**
+ * @brief FRAM SPI Tx API for ADE9178 Eval board
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pData  - pointer to the data to be sent
+ * @param[in]  numBytes  - num of bytes to send
+ *
+ * @return  error or success
+ */
+int32_t EvbStartFramSpiTx(void *hEvb, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief FRAM SPI Rx API for ADE9178 Eval board
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pData  - pointer to the data to be received
+ * @param[in]  numBytes  - num of bytes to receive
+ * @return  error or success
+ */
+int32_t EvbStartFramSpiRx(void *hEvb, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief FRAM SPI Rx API for ADE9178 Eval board
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  pTxData  - pointer to the data to be received
+ * @param[in]  pRxData  - pointer to the data to be received
+ * @param[in]  numBytes  - num of bytes to receive
+ * @return  error or success
+ */
+int32_t EvbStartFramSpiTxRxAsync(void *hEvb, uint8_t *pTxData, uint8_t *pRxData, uint32_t numBytes);
+
+/**
+ * @brief Configure the GPIO pin for SPI chip select
+ */
+void EvbSetSpiChipSelect(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_SPI_H__ */
+
+/** @} */

--- a/generic/include/adi_evb_timer.h
+++ b/generic/include/adi_evb_timer.h
@@ -1,0 +1,102 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+/**
+ * @file        adi_evb_timer.h
+ * @brief       SPI APIs for ADE9178 Eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_TIMER_H__
+#define __ADI_EVB_TIMER_H__
+
+/*============= I N C L U D E S =============*/
+
+#include "board_cfg.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+
+/**
+ * @brief get timer value
+ * @return 0 -  success
+ */
+uint32_t EvbGetTime(void);
+
+/**
+ * @brief get maximum timer value
+ * @return 0 -  success
+ */
+uint32_t EvbGetMaxTime(void);
+
+/**
+ * @brief  start timer
+ */
+void EvbStartTimer(void);
+
+/**
+ * @brief  start timer
+ */
+void EvbStartLpTimer(void);
+
+/**
+ * @brief  start timer
+ */
+void EvbStopLpTimer(void);
+
+/**
+ * @brief  stop timer
+ */
+void EvbStopTimer(void);
+
+/**
+ * @brief Initializes PWM timer
+ * @return 0 -  success
+ *
+ */
+uint32_t EvbCf1TimerInit(void);
+/**
+ * @brief Read PWM timer count value
+ * @returns  PWM timer counter
+ *
+ */
+uint32_t EvbReadCf1Timer(void);
+/**
+ * @brief Update end time for PWM pulse
+ * @param[in] endCount	  - Timer count when the pulse ends
+ */
+void EvbUpdateCf1TimerEndTime(uint32_t endCount);
+
+/**
+ * @brief Start PWM timer
+ * @param[in] startCount  - Timer count when the pulse is triggered
+ * @param[in] endCount	  - Timer count when the pulse ends
+ *
+ */
+void EvbStartCf1Timer(uint32_t startCount, uint32_t endCount);
+
+/**
+ * @brief Stop PWM timer
+ */
+void EvbStopCf1Timer(void);
+
+/**
+ * @brief Set the LPTIM output pin to be used for TDM
+ */
+void EvbSetLptimOutput(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_TIMER_H__ */
+
+/** @} */

--- a/generic/include/adi_evb_uart.h
+++ b/generic/include/adi_evb_uart.h
@@ -1,0 +1,113 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+/**
+ * @file        adi_evb_uart.h
+ * @brief       SPI APIs for ADE9178 Eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __ADI_EVB_UART_H__
+#define __ADI_EVB_UART_H__
+
+/*============= I N C L U D E S =============*/
+
+#include "board_cfg.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+
+/**
+ * @brief Sets uart baudrate for waveform streaming
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  baudRate  - baud rate
+ * @return  success or error
+ */
+int32_t EvbSetAdeWfsUartBaudrate(void *hEvb, uint32_t baudRate);
+
+/**
+ * @brief Starts receiving data through ADE9178 WFS uart
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  numBytes  - num of bytes to receive
+ * @return  success or error
+ */
+int32_t EvbStartAdeWfsUartRx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes);
+/**
+ * @brief Starts receiving data through Host UART and waits till the data is received.
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  numBytes  - num of bytes to stream
+ * @return  success or error
+ */
+int32_t EvbStartHostUartRx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes);
+
+/**
+ * @brief Starts sending data through Host UART and waits till the completion
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  numBytes  - num of bytes to stream
+ * @return  success or error
+ */
+int32_t EvbStartHostUartTx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes);
+
+/**
+ * @brief Returns the Tx completion status
+ *
+ * @return  0 - Not complete , 1 complete
+ */
+int32_t EvbGetTxStatus(void);
+
+/**
+ * @brief Starts sending data through Host UART
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  numBytes  - num of bytes to stream
+ * @return  success or error
+ */
+int32_t EvbStartHostUartTxAsync(void *hEvb, uint8_t *pBuffer, uint32_t numBytes);
+
+/**
+ * @brief Initiates data transmission through Host UART and waits for completion. This API
+ * internally calls EvbStartHostUartTxAsync function. It is primarily added for the MAX32670, as
+ * sending characters requires some delay between them.
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  numBytes  - num of bytes to stream
+ * @return  success or error
+ */
+int32_t EvbPutBuffer(uint8_t *pBuffer, uint32_t numBytes);
+
+/**
+ * @brief Initiates data transmission through Host UART and waits for completion. This API
+ * internally calls EvbStartHostUartTxAsync function. It is primarily added for the MAX32670, as
+ * sending characters requires some delay between them.
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  numBytes  - num of bytes to stream
+ * @return  success or error
+ */
+int32_t EvbPutBufferNb(uint8_t *pBuffer, uint32_t numBytes);
+
+/**
+ * @brief Starts receiving data through ADE9178 WFS uart
+ * @param[in]  pBuffer  -pointer to the array of data to be sent
+ * @param[in]  hEvb - Evb handle obtained from EvbInit
+ * @param[in]  numBytes  - num of bytes to receive
+ * @return  success or error
+ */
+int32_t EvbStartHostUartRxAsync(void *hEvb, uint8_t *pBuffer, uint32_t numBytes);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ADI_EVB_UART_H__ */
+
+/** @} */

--- a/generic/include/message.h
+++ b/generic/include/message.h
@@ -1,0 +1,82 @@
+/******************************************************************************
+ Copyright (c) 2023 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ *  @file   message.h
+ * @addtogroup ADI_CLI
+ *  @brief  Defines for message
+ * @{
+ */
+
+#ifndef __MESSAGE_H__
+#define __MESSAGE_H__
+
+/*============= I N C L U D E S =============*/
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============= D E F I N E S =============*/
+/** Maximum message size value */
+#define MAX_MSG_SIZE 512
+/* FIXME : Maximum buffer size can be reduced based on FlushMessages*/
+/** Maximum stored message size value */
+#define MAX_MSG_STORAGE_SIZE 1024 * 10
+/** Prints Info  Message as such without new line */
+#define INFO_MSG_RAW(...) PrintMessage("RAW", __VA_ARGS__);
+/** Prints Info  Message */
+#define INFO_MSG(...) PrintMessage("", __VA_ARGS__);
+/** Prints warn message */
+#define WARN_MSG(...) PrintMessage("Warn : ", __VA_ARGS__);
+/** Prints error message */
+#define ERROR_MSG(...) PrintMessage("Error : ", __VA_ARGS__);
+/** Prints debug message */
+#ifdef ENABLE_DEBUG
+#define DEBUG_MSG(...) PrintMessage("Debug : ", __VA_ARGS__);
+#else
+#define DEBUG_MSG(...)
+#endif
+/** Prints debug message as such without new line */
+#ifdef ENABLE_DEBUG
+#define DEBUG_MSG_RAW(...) PrintMessage("DBGRAW", __VA_ARGS__);
+#else
+#define DEBUG_MSG_RAW(...) NULL
+#endif
+
+/*============= F U N C T I O N  P R O T O T Y P E S =============*/
+
+/**
+ * @details Prints message
+ * @param[in] pMsgType - Type of message to be printed
+ * @param[in] pFormat  - Format specifier for the message
+ * @return status      - SUCCESS - 0
+ *                     - FAILURE - 1
+ */
+int32_t PrintMessage(char *pMsgType, char *pFormat, ...);
+
+/**
+ * @details FlushMessages
+ * @return success when messages are flushed.
+ */
+int32_t EvbFlushMessages(void);
+/**
+ * @details Initializes message buffer
+ */
+void EvbInitMessageBuffer(void);
+/** Gets free space in the message buffer*/
+uint32_t EvbGetFreeMessageSpace(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MESSAGE_H__ */
+
+/**
+ * @}
+ */

--- a/generic/source/message.c
+++ b/generic/source/message.c
@@ -1,0 +1,159 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     message.c
+ * @brief    This file contains API's to print different types of messages to
+ * user
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+#include "message.h"
+#include "adi_evb.h"
+#include <stdio.h>
+#include <string.h>
+
+/*=============  D A T A  =============*/
+
+/** Buffer to store message string */
+SECTION(DMA_BUFFER) static char msgString[MAX_MSG_SIZE];
+/** Buffer to store message string */
+SECTION(DMA_BUFFER) static char msgStringToCopy[MAX_MSG_SIZE];
+/** Buffer to write and store the message */
+SECTION(DMA_BUFFER) static uint8_t messageBuffer0[MAX_MSG_STORAGE_SIZE];
+/** Buffer to write and store the message */
+SECTION(DMA_BUFFER) static uint8_t messageBuffer1[MAX_MSG_STORAGE_SIZE];
+/** Buffer to write message */
+static uint8_t *pBufferToWrite = &messageBuffer0[0];
+/** message bytes stored */
+static uint32_t msgBytesStored = 0;
+/** dummy data to be sent for the HostUartTxAsync API. As this API checks whether the first argument
+ * of API is NULL or not. */
+static int32_t dummyUartData = 0;
+
+/*============= F U N C T I O N  P R O T O T Y P E S =============*/
+
+/**
+ * @details CopyToBuffer
+ * @param[in] pMessage - pointer to pMessage.
+ * @return[in] status - 0 on Success
+ *                    - 1 on Failure
+ */
+static int32_t CopyToBuffer(char *pMessage);
+
+/*=============  C O D E  =============*/
+
+/**
+ *@brief Function Definition section
+ */
+
+void EvbInitMessageBuffer(void)
+{
+    msgBytesStored = 0;
+}
+
+/**
+ * @details Prints message
+ */
+// added this to avoid warning format sring is not a literal.
+__attribute__((__format__(__printf__, 2, 0))) int32_t PrintMessage(char *pMsgType, char *pFormat,
+                                                                   ...)
+{
+    int32_t status = 0;
+    int32_t ret = 0;
+    va_list pArgs;
+    va_start(pArgs, pFormat);
+    vsnprintf(msgString, MAX_MSG_SIZE, pFormat, pArgs);
+
+    if ((strcmp(pMsgType, "RAW") == 0) || (strcmp(pMsgType, "DBGRAW") == 0))
+    {
+        va_end(pArgs);
+        /* Just print the message as such*/
+        status = CopyToBuffer(msgString);
+    }
+    else
+    {
+        ret = snprintf(msgStringToCopy, MAX_MSG_SIZE, "%s\n\r", msgString);
+        va_end(pArgs);
+        if (ret >= 0)
+        {
+
+            CopyToBuffer(pMsgType);
+            status = CopyToBuffer(msgStringToCopy);
+        }
+        else
+        {
+            status = 1;
+        }
+    }
+
+    return status;
+}
+
+/**
+ * @details Copy pMessage into message buffer
+ * @param[in] pMessage - pointer to pMessage buffer.
+ * @return[in] status - 0 on Success, 1 on Failure
+ */
+int32_t CopyToBuffer(char *pMessage)
+{
+    int32_t space = (int32_t)(MAX_MSG_STORAGE_SIZE - msgBytesStored - 1);
+    int32_t bytesToWrite = (int32_t)strlen(pMessage);
+    int32_t status = 0;
+
+    if (space >= bytesToWrite)
+    {
+        memcpy(&pBufferToWrite[msgBytesStored], pMessage, (size_t)bytesToWrite);
+        msgBytesStored += (uint32_t)bytesToWrite;
+    }
+    else
+    {
+        status = 1;
+    }
+
+    return status;
+}
+
+int32_t EvbFlushMessages(void)
+{
+    int32_t status = 0;
+    static int32_t bufId = 0;
+    int32_t isTxComplete;
+
+    isTxComplete = EvbGetTxStatus();
+    /* Do not flush until previous transfer is complete*/
+    if ((msgBytesStored > 0) && (isTxComplete == true))
+    {
+        EvbStartHostUartTxAsync(&dummyUartData, pBufferToWrite, msgBytesStored);
+        if (bufId == 0)
+        {
+            pBufferToWrite = &messageBuffer1[0];
+        }
+        else
+        {
+            pBufferToWrite = &messageBuffer0[0];
+        }
+        // Toggle the bufID
+        bufId ^= 0x1;
+        msgBytesStored = 0;
+    }
+    isTxComplete = EvbGetTxStatus();
+    if ((isTxComplete == false) || (msgBytesStored > 0))
+    {
+        status = 1;
+    }
+    return status;
+}
+
+uint32_t EvbGetFreeMessageSpace(void)
+{
+    uint32_t freeSpace;
+    freeSpace = MAX_MSG_STORAGE_SIZE - msgBytesStored;
+    return freeSpace;
+}
+
+/**
+ * @}
+ */

--- a/max/eval_ade9178/CMakeLists.txt
+++ b/max/eval_ade9178/CMakeLists.txt
@@ -1,0 +1,101 @@
+cmake_minimum_required(VERSION 3.22)
+project(max32670 C)
+
+option(USE_IIO "Compile IIO board_support sources" OFF)
+add_library(max32670 INTERFACE)
+
+# Enable CMake support for ASM and C languages
+enable_language(C ASM)
+
+set(MAX32670_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
+
+# Define MAXIM_DRIVERS path
+set(MAXIM_DRIVERS C:/MaximSDK CACHE PATH "Path to MAXIM_DRIVERS directory")
+
+# Add project symbols (macros)
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC
+    $<$<CONFIG:Debug>:DEBUG>
+    # Add user defined symbols
+    MAX32670
+)
+
+# Needed to print variables in cmake
+include(CMakePrintHelpers)
+
+set(BOARD_SRC ${MAX32670_ROOT_DIR}/source/eval_ade9178.c
+				${MAX32670_ROOT_DIR}/source/eval_ade9178_control.c
+				${MAX32670_ROOT_DIR}/source/eval_ade9178_spi.c
+                ${MAX32670_ROOT_DIR}/source/eval_ade9178_gpio.c
+                ${MAX32670_ROOT_DIR}/source/eval_ade9178_uart.c
+                ${MAX32670_ROOT_DIR}/../source/max3267x_spi_config.c
+                ${MAX32670_ROOT_DIR}/../source/max3267x_uart_config.c
+                ${MAX32670_ROOT_DIR}/../source/max3267x_dma_config.c
+                ${MAX32670_ROOT_DIR}/../source/max3267x_timer_config.c
+                
+)
+
+# Add MaximSDK driver source files
+file(GLOB_RECURSE DEVICE_SOURCES ${MAXIM_DRIVERS}/Libraries/CMSIS/Device/Maxim/Source/*.c)
+
+set(MAXIM_FILES    # HAL driver sources
+        ${MAXIM_DRIVERS}/Libraries/CMSIS/Device/Maxim/MAX32670/Source/GCC/startup_max32670.s
+        ${MAXIM_DRIVERS}/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+        ${MAXIM_DRIVERS}/Libraries/CMSIS/Device/Maxim/MAX32670/Source/heap.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SYS/mxc_assert.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SYS/mxc_delay.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SYS/mxc_lock.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SYS/nvic_table.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SYS/pins_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SYS/sys_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/AES/aes_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/AES/aes_revb.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/DMA/dma_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/GPIO/gpio_common.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/GPIO/gpio_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/GPIO/gpio_reva.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SPI/spi_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/SPI/spi_reva1.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/TMR/tmr_common.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/TMR/tmr_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/UART/uart_common.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/UART/uart_revb.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/FLC/flc_common.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/FLC/flc_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/FLC/flc_reva.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/ICC/icc_common.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/ICC/icc_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/ICC/icc_reva.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/TMR/tmr_common.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/TMR/tmr_me15.c
+        ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/TMR/tmr_revb.c
+        ${DEVICE_SOURCES}
+)
+
+file(GLOB HEADER_DIRS LIST_DIRECTORIES true ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Source/*)
+
+target_sources(max32670 INTERFACE
+    ${MAXIM_FILES}
+    ${BOARD_SRC}
+)
+
+target_include_directories(max32670 INTERFACE
+    ${MAX32670_ROOT_DIR}/include
+    ${MAX32670_ROOT_DIR}/../include
+    ${MAX32670_ROOT_DIR}/include/config
+    ${MAXIM_DRIVERS}/Libraries/PeriphDrivers/Include/MAX32670
+    ${MAXIM_DRIVERS}/Libraries/CMSIS/5.9.0/Core/Include
+    ${MAXIM_DRIVERS}/Libraries/CMSIS/Device/Maxim/MAX32670/Include
+    ${MAXIM_DRIVERS}/Libraries/CMSIS/Include
+    ${MAXIM_DRIVERS}/Libraries/Boards/MAX32670
+    ${HEADER_DIRS}
+)
+
+target_link_directories(max32670 INTERFACE
+)
+
+target_link_libraries(max32670 INTERFACE
+)

--- a/max/eval_ade9178/include/config/board_cfg.h
+++ b/max/eval_ade9178/include/config/board_cfg.h
@@ -1,0 +1,92 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file        board_cfg.h
+ * @brief       configuration file for ADE9178 eval board
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __BOARD_CFG_H__
+#define __BOARD_CFG_H__
+
+/*============= I N C L U D E S =============*/
+
+#include "gpio.h"
+#include "max32670.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/** Port for HOST_RDY and HOST_ERR pins  */
+#define BOARD_CFG_ADECOMM_PORT MXC_GPIO0
+/** Port for IRQ pins  */
+#define BOARD_CFG_ADEIRQ_PORT MXC_GPIO0
+/** Number of port 0 GPIOs */
+#define BOARD_CFG_NUM_PORT0_GPIOS 8
+/** dummy macro */
+#define BOARD_CFG_MB85RS_PRODUCT_ID 0
+/** Pin - HOST_RDY */
+#define BOARD_CFG_HOST_RDY_PIN MXC_GPIO_PIN_22
+/** Pin - HOST_ERR */
+#define BOARD_CFG_HOST_ERR_PIN MXC_GPIO_PIN_21
+/**  Pin  -IRQ0*/
+#define BOARD_CFG_IRQ0_PIN MXC_GPIO_PIN_27
+/**  Pin -  IRQ1 */
+#define BOARD_CFG_IRQ1_PIN MXC_GPIO_PIN_26
+/**  Pin - IRQ2 */
+#define BOARD_CFG_IRQ2_PIN MXC_GPIO_PIN_25
+/**  Pin - IRQ3 */
+#define BOARD_CFG_IRQ3_PIN MXC_GPIO_PIN_23
+/**  Pin - CF1 */
+#define BOARD_CFG_CF1_PIN MXC_GPIO_PIN_6
+/**  Pin - CF2 */
+#define BOARD_CFG_CF2_PIN MXC_GPIO_PIN_20
+/**  Pin - HOST_CS */
+#define BOARD_CFG_SS_PIN MXC_GPIO_PIN_5
+/** ADE9178 SPI */
+#define BOARD_CFG_ADE9178_SPI MXC_SPI0
+/** ADE9178 WFS UART */
+#define BOARD_CFG_WFS_UART MXC_UART1
+/** ADE9178 Host UART */
+#define BOARD_CFG_HOST_UART MXC_UART0
+/** Number of SPI0 slaves  */
+#define BOARD_CFG_ADE9178_SPI_NUM_SLAVES 1
+/** Slave index */
+#define BOARD_CFG_ADE9178_SS_INDEX 0
+/**  Pin -  ADC reset */
+#define BOARD_CFG_ADC_RESET_PIN MXC_GPIO_PIN_18
+/**  Pin -  ADE reset */
+#define BOARD_CFG_ADE_RESET_PIN MXC_GPIO_PIN_19
+/**  Pin -  led */
+#define BOARD_CFG_LED1_PIN MXC_GPIO_PIN_7
+/**  Pin -  led */
+#define BOARD_CFG_LED2_PIN MXC_GPIO_PIN_30
+/**  Reset type either for EVB or EVK */
+#define BOARD_CFG_RESET_TYPE 0
+/**  Timer  clock type */
+#define BOARD_CFG_SYSTEM_TIMER_CLOCK_TYPE 0
+/**  Timer */
+#define BOARD_CFG_SYSTEM_TIMER MXC_TMR0
+
+/** Empty define - The EVK doesn't require a section attribute */
+#define SECTION(SECTION_NAME)
+/** Empty define - The EVK doesn't require DMA Buffer section for the linker */
+#define DMA_BUFFER
+/** Empty define - The EVK doesn't require FRAM Buffer section for the linker */
+#define FRAM_BUFFER
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __BOARD_CFG_H__ */
+
+/** @} */

--- a/max/eval_ade9178/max32670.ld
+++ b/max/eval_ade9178/max32670.ld
@@ -1,0 +1,156 @@
+/******************************************************************************
+ * Copyright (C) 2023 Maxim Integrated Products, Inc., All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL MAXIM INTEGRATED BE LIABLE FOR ANY CLAIM, DAMAGES
+ * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Except as contained in this notice, the name of Maxim Integrated
+ * Products, Inc. shall not be used except as stated in the Maxim Integrated
+ * Products, Inc. Branding Policy.
+ *
+ * The mere transfer of this software does not imply any licenses
+ * of trade secrets, proprietary technology, copyrights, patents,
+ * trademarks, maskwork rights, or any other form of intellectual
+ * property whatsoever. Maxim Integrated Products, Inc. retains all
+ * ownership rights.
+ *
+ ******************************************************************************/
+
+MEMORY {
+    FLASH (rx) : ORIGIN = 0x10000000, LENGTH = 384K /* 384kB "FLASH" */
+    /* SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 128K */ /* 160kB SRAM with ECC*/
+    /*^ If ECC is enabled, the stack size must be reduced.  Otherwise, a
+        HardFault will occur on startup as the stack is expanded into the
+        ECC's reserved SRAM space.
+    */
+    SRAM (rwx) : ORIGIN = 0x20000000, LENGTH = 160K /* 160kB SRAM, no ECC */
+
+}
+
+SECTIONS {
+
+    .text :
+    {
+        _text = .;
+        KEEP(*(.isr_vector))
+        *(.text*)    /* program code */
+        *(.rodata*)  /* read-only data: "const" */
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        /* C++ Exception handling */
+        KEEP(*(.eh_frame*))
+        _etext = .;
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    /* it's used for C++ exception handling      */
+    /* we need to keep this to avoid overlapping */
+    .ARM.exidx :
+    {
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+    } > FLASH
+
+    .data :
+    {
+        _data = ALIGN(., 4);
+        *(vtable)
+        *(.data*)           /*read-write initialized data: initialized global variable*/
+        *(.spix_config*)    /* SPIX configuration functions need to be run from SRAM */
+        *(.flashprog*)      /* Flash program */
+
+        /* These array sections are used by __libc_init_array to call static C++ constructors */
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        _edata = ALIGN(., 4);
+    } > SRAM AT>FLASH
+    __load_data = LOADADDR(.data);
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _bss = .;
+        *(.bss*)     /*read-write zero initialized data: uninitialzed global variable*/
+        *(COMMON)
+        _ebss = ALIGN(., 4);
+    } > SRAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(SRAM) + LENGTH(SRAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > SRAM
+
+    .heap (COPY):
+    {
+        . = ALIGN(4);
+        *(.heap*)
+        __HeapLimit = ABSOLUTE(__StackLimit);
+    } > SRAM
+
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= _ebss, "region RAM overflowed with stack")
+}

--- a/max/eval_ade9178/source/eval_ade9178.c
+++ b/max/eval_ade9178/source/eval_ade9178.c
@@ -1,0 +1,119 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     eval_ade9178.c
+ * @brief
+ * @{
+ */
+
+/*============= I N C L U D E S =============*/
+
+#include "adi_evb.h"
+#include "app_cfg.h"
+#include "board_cfg.h"
+#include "dma.h"
+#include "icc.h"
+#include "max3267x_timer_config.h"
+#include "nvic_table.h"
+#include <stdint.h>
+#include <stdio.h>
+
+/*=============  D A T A  =============*/
+/** Mem init */
+static int32_t MemInit(void);
+/** evb info */
+static ADI_EVB_INFO evbInfo;
+
+/*=============  C O D E  =============*/
+int32_t EvbInit(void **phEvb, ADI_EVB_CONFIG *pConfig)
+{
+    int32_t status = 0;
+    ADI_EVB_INFO *pEvb = &evbInfo;
+
+    if (pConfig == NULL)
+    {
+        pConfig = &pEvb->config;
+    }
+
+    MemInit();
+    MXC_DMA_Init();
+
+#if APP_CFG_ENABLE_ADE9178_SPI == 1
+
+    status = EvbInitSpi(&pEvb->hSpi, &pConfig->spiConfig);
+#endif
+
+#if APP_CFG_ENABLE_GPIO == 1
+    if (status == 0)
+    {
+        status = EvbInitGpio(&pEvb->hGpio, &pConfig->gpioConfig);
+    }
+#endif
+    if (status == 0)
+    {
+        status = EvbInitUart(&pEvb->hUart, &pConfig->uartConfig);
+    }
+
+#if APP_CFG_ENABLE_SYSTEM_TIMER == 1
+    if (status == 0)
+    {
+        status = EvbTimerInit();
+    }
+#endif
+
+    if (status == 0)
+    {
+        *phEvb = &evbInfo;
+    }
+
+    return status;
+}
+
+int32_t MemInit(void)
+{
+    int32_t status = 0;
+    NVIC_SetRAM();
+    MXC_ICC_Enable();
+    // give high GPIO Drive Strength
+    // P0.0 used for Single-Wire Debug I/O
+    // P0.1,P0.2,P0.3,P0.4,P0.5 used for SPI0 (Drive Strength : 4mA)
+    // if its high Strength then unble to communicate with the debug port
+    MXC_GPIO0->ds0 = 0xFFFFFFC0;
+    MXC_GPIO0->ds1 = 0xFFFFFFFE;
+    return status;
+}
+
+#if APP_CFG_ENABLE_SYSTEM_TIMER == 1
+uint32_t EvbTimerInit()
+{
+    int32_t status;
+    status = MaxTimerInit(BOARD_CFG_SYSTEM_TIMER);
+    return status;
+}
+
+uint32_t EvbGetTime()
+{
+    return MaxGetTime(BOARD_CFG_SYSTEM_TIMER);
+}
+
+uint32_t EvbGetMaxTime()
+{
+    return MaxGetMaximumTime();
+}
+
+void EvbStartTimer()
+{
+    MaxStartTimer(BOARD_CFG_SYSTEM_TIMER);
+}
+
+void EvbStopTimer()
+{
+    MaxStopTimer(BOARD_CFG_SYSTEM_TIMER);
+}
+#endif
+
+/**
+ * @}
+ */

--- a/max/eval_ade9178/source/eval_ade9178_control.c
+++ b/max/eval_ade9178/source/eval_ade9178_control.c
@@ -1,0 +1,170 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     eval_ade9178_control.c
+ * @brief
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+
+#include "adi_evb.h"
+#include "gpio.h"
+#include "mxc_delay.h"
+#include <stdint.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/** Duration in ms of the low pulse. */
+#define RESET_PULSE_MSEC 10
+/**Duration in ms to wait after the low pulse. */
+#define RESET_WAIT_MSEC 200
+
+/*=============  D A T A  =============*/
+
+// The Keil pack uses the DFP pack provided by Keil. The MAX32670 pack is not updated with the
+// latest MSDK changes.
+#ifdef DISABLE_MSDK
+/** Array of pins used to reset other devices on the evaluation board. */
+static const mxc_gpio_cfg_t resetPins[] = {
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_ADC_RESET_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO},
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_ADE_RESET_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO}};
+/** Array of pins used to control LEDs on the evaluation board. */
+static const mxc_gpio_cfg_t ledPins[] = {
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_LED1_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO},
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_LED2_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO}};
+#else
+/** Array of pins used to reset other devices on the evaluation board. */
+static const mxc_gpio_cfg_t resetPins[] = {
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_ADC_RESET_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_3},
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_ADE_RESET_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_3}};
+/** Array of pins used to control LEDs on the evaluation board. */
+static const mxc_gpio_cfg_t ledPins[] = {
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_LED1_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_3},
+    {BOARD_CFG_ADEIRQ_PORT, BOARD_CFG_LED2_PIN, MXC_GPIO_FUNC_OUT, MXC_GPIO_PAD_PULL_UP,
+     MXC_GPIO_VSSEL_VDDIO, MXC_GPIO_DRVSTR_3}};
+#endif
+
+/** Number of reset pins on the evaluation board. */
+static const uint32_t numReset = (sizeof(resetPins) / sizeof(mxc_gpio_cfg_t));
+/** Number of LEDs on the evaluation board. */
+static const uint32_t numLed = (sizeof(ledPins) / sizeof(mxc_gpio_cfg_t));
+
+/*=============  C O D E  =============*/
+
+/**
+ * @brief       Toggles an active-low reset pin.
+ * @param[in]   idx         Index of the reset pin to toggle.
+ * @param[in]   pulseMs     Duration in ms of the low pulse.
+ * @param[in]   waitMs      Duration in ms to wait after the low pulse.
+ * @return      ADI_EVB_STATUS_SUCCESS on success.
+ */
+int32_t ToggleResetB(uint32_t idx, uint32_t pulseMs, uint32_t waitMs);
+
+int32_t EvbDelayMs(uint32_t delayMs)
+{
+    MXC_Delay(MXC_DELAY_MSEC(delayMs));
+    return ADI_EVB_STATUS_SUCCESS;
+}
+
+int32_t EvbResetAde(void)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+    status = ToggleResetB(1, RESET_PULSE_MSEC, RESET_WAIT_MSEC);
+    EvbDelayMs(RESET_WAIT_MSEC);
+    return status;
+}
+
+int32_t EvbResetAdcs(void)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+    status = ToggleResetB(0, RESET_PULSE_MSEC, RESET_WAIT_MSEC);
+    return status;
+}
+
+int32_t EvbResetAll(void)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+#if BOARD_CFG_RESET_TYPE == 0
+    // Both for Ade9178 and Adc reset pin is tied together.
+    status = EvbResetAde();
+#else
+    status = EvbResetAdcs();
+    status = EvbResetAde();
+#endif
+    return status;
+}
+
+int32_t EvbLedOn(uint32_t idx)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+    /* Turn on the LED if a valid index is provided. */
+    if (idx < numLed)
+    {
+        MXC_GPIO_OutClr(ledPins[idx].port, ledPins[idx].mask);
+    }
+    else
+    {
+        status = ADI_EVB_STATUS_INVALID_INDEX;
+    }
+    return status;
+}
+
+int32_t EvbLedOff(uint32_t idx)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+    /* Turn off the LED if a valid index is provided. */
+    if (idx < numLed)
+    {
+        MXC_GPIO_OutSet(ledPins[idx].port, ledPins[idx].mask);
+    }
+    else
+    {
+        status = ADI_EVB_STATUS_INVALID_INDEX;
+    }
+    return status;
+}
+
+int32_t EvbLedFlash(uint32_t idx, uint32_t numFlashes, uint32_t flashMs)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+    uint32_t i;
+    for (i = 0; i < numFlashes; i++)
+    {
+        MXC_GPIO_OutClr(ledPins[idx].port, ledPins[idx].mask);
+        EvbDelayMs(flashMs);
+        MXC_GPIO_OutSet(ledPins[idx].port, ledPins[idx].mask);
+        EvbDelayMs(flashMs);
+    }
+    return status;
+}
+
+int32_t ToggleResetB(uint32_t idx, uint32_t pulseMs, uint32_t waitMs)
+{
+    int32_t status = ADI_EVB_STATUS_SUCCESS;
+    if (idx < numReset)
+    {
+        MXC_GPIO_OutClr(resetPins[idx].port, resetPins[idx].mask);
+        EvbDelayMs(pulseMs);
+        MXC_GPIO_OutSet(resetPins[idx].port, resetPins[idx].mask);
+        EvbDelayMs(waitMs);
+    }
+    else
+    {
+        status = ADI_EVB_STATUS_INVALID_INDEX;
+    }
+    return status;
+}
+
+/**
+ * @}
+ */

--- a/max/eval_ade9178/source/eval_ade9178_gpio.c
+++ b/max/eval_ade9178/source/eval_ade9178_gpio.c
@@ -1,0 +1,150 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     eval_ade9178_gpio.c
+ * @brief
+ * @{
+ */
+/*============= I N C L U D E S =============*/
+
+#include "adi_evb.h"
+#include "app_cfg.h"
+#include "mxc_device.h"
+#include <stdint.h>
+#include <stdio.h>
+
+/*=============  D A T A  =============*/
+/** evb gpio info*/
+typedef struct
+{
+    /** callback */
+    ADI_EVB_GPIO_CALLBACK pfGpioCallback;
+
+} EVB_GPIO_INFO;
+
+/** irq pins */
+static uint32_t inputPinsIrqFalling[] = {BOARD_CFG_IRQ0_PIN, BOARD_CFG_IRQ1_PIN, BOARD_CFG_IRQ2_PIN,
+                                         BOARD_CFG_IRQ3_PIN, BOARD_CFG_CF1_PIN,  BOARD_CFG_CF2_PIN};
+
+static uint32_t inputPinsIrqBoth[] = {BOARD_CFG_HOST_RDY_PIN, BOARD_CFG_HOST_ERR_PIN};
+
+static uint32_t outputPins[] = {BOARD_CFG_ADC_RESET_PIN, BOARD_CFG_ADE_RESET_PIN,
+                                BOARD_CFG_LED1_PIN, BOARD_CFG_LED2_PIN};
+
+/** evb gpio info*/
+static EVB_GPIO_INFO gpioInfo;
+
+/** gpio irq handler*/
+void GpioIrqHandler(void);
+static void EvbConfigureOutPin(mxc_gpio_regs_t *pGpio, uint32_t mask);
+
+/*=============  C O D E  =============*/
+
+int32_t EvbInitGpio(void **phGpio, ADI_EVB_GPIO_CONFIG *pConfig)
+{
+    IRQn_Type irqn;
+    int32_t status = 0;
+    int32_t i;
+    mxc_gpio_cfg_t config;
+    int32_t numPins = sizeof(inputPinsIrqFalling) / sizeof(inputPinsIrqFalling[0]);
+
+    config.port = BOARD_CFG_ADEIRQ_PORT;
+    config.pad = MXC_GPIO_PAD_PULL_UP;
+    config.func = MXC_GPIO_FUNC_IN;
+    config.vssel = MXC_GPIO_VSSEL_VDDIOH;
+
+    for (i = 0; i < numPins; i++)
+    {
+        config.mask = inputPinsIrqFalling[i];
+        MXC_GPIO_Config(&config);
+        MXC_GPIO_IntConfig(&config, MXC_GPIO_INT_FALLING);
+    }
+
+    numPins = sizeof(inputPinsIrqBoth) / sizeof(inputPinsIrqBoth[0]);
+    for (i = 0; i < numPins; i++)
+    {
+        config.mask = inputPinsIrqBoth[i];
+        MXC_GPIO_Config(&config);
+        MXC_GPIO_IntConfig(&config, MXC_GPIO_INT_BOTH);
+    }
+
+    config.func = MXC_GPIO_FUNC_OUT;
+    config.vssel = MXC_GPIO_VSSEL_VDDIO;
+
+    numPins = sizeof(outputPins) / sizeof(outputPins[0]);
+    for (i = 0; i < numPins; i++)
+    {
+        config.mask = outputPins[i];
+        EvbConfigureOutPin(BOARD_CFG_ADECOMM_PORT, outputPins[i]);
+    }
+
+    irqn = MXC_GPIO_GET_IRQ(MXC_GPIO_GET_IDX(BOARD_CFG_ADECOMM_PORT));
+    NVIC_SetPriority(irqn, APP_CFG_PORT0_GPIO_INT_PRIO);
+    NVIC_SetVector(irqn, (uint32_t)GpioIrqHandler);
+    NVIC_EnableIRQ(irqn);
+
+    *phGpio = &gpioInfo;
+    gpioInfo.pfGpioCallback = pConfig->pfGpioCallback;
+
+    return status;
+}
+
+void EvbEnableAllGPIOIrq(void)
+{
+    int32_t idx;
+    uint32_t pins[2] = {BOARD_CFG_HOST_RDY_PIN, BOARD_CFG_HOST_ERR_PIN};
+    uint32_t irqPins[6] = {BOARD_CFG_IRQ0_PIN, BOARD_CFG_IRQ1_PIN, BOARD_CFG_IRQ2_PIN,
+                           BOARD_CFG_IRQ3_PIN, BOARD_CFG_CF1_PIN,  BOARD_CFG_CF2_PIN};
+    for (idx = 0; idx < 2; idx++)
+    {
+        EvbEnableGPIOIrq((uint32_t)BOARD_CFG_ADECOMM_PORT, pins[idx]);
+    }
+
+    for (idx = 0; idx < 6; idx++)
+    {
+        EvbEnableGPIOIrq((uint32_t)BOARD_CFG_ADEIRQ_PORT, irqPins[idx]);
+    }
+}
+
+int32_t EvbGetPinState(uint32_t port, uint32_t flag)
+{
+    uint32_t pinState;
+    pinState = (uint8_t)MXC_GPIO_InGet((mxc_gpio_regs_t *)port, flag);
+    return pinState;
+}
+
+void EvbEnableGPIOIrq(uint32_t port, uint32_t pin)
+{
+    MXC_GPIO_EnableInt((mxc_gpio_regs_t *)port, pin);
+}
+
+void EvbDisableGPIOIrq(uint32_t port, uint32_t pin)
+{
+    MXC_GPIO_DisableInt((mxc_gpio_regs_t *)port, pin);
+}
+
+void GpioIrqHandler(void)
+{
+    uint32_t stat;
+    stat = BOARD_CFG_ADECOMM_PORT->intfl;
+    if (gpioInfo.pfGpioCallback != NULL)
+    {
+        gpioInfo.pfGpioCallback((uint32_t)BOARD_CFG_ADECOMM_PORT, stat);
+    }
+    BOARD_CFG_ADECOMM_PORT->intfl_clr = stat;
+}
+
+static void EvbConfigureOutPin(mxc_gpio_regs_t *pGpio, uint32_t mask)
+{
+    pGpio->en0_set = mask;
+    pGpio->en1_clr = mask;
+    pGpio->en2_clr = mask;
+    pGpio->out_set = mask;
+    pGpio->outen_set = mask;
+}
+
+/**
+ * @}
+ */

--- a/max/eval_ade9178/source/eval_ade9178_spi.c
+++ b/max/eval_ade9178/source/eval_ade9178_spi.c
@@ -1,0 +1,212 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     eval_ade9178_spi.c
+ * @brief
+ * @{
+ */
+
+/*============= I N C L U D E S =============*/
+
+#include "adi_evb.h"
+#include "app_cfg.h"
+#include "dma.h"
+#include "icc.h"
+#include "max3267x_dma_config.h"
+#include "max3267x_spi_config.h"
+#include "max3267x_uart_config.h"
+#include "mxc_device.h"
+#include "nvic_table.h"
+#include <stdint.h>
+#include <stdio.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/** Evb spi info */
+typedef struct
+{
+    /** maxim spi instance info */
+    MAX_SPI_INSTANCE adeSpiInfo;
+    /** callback */
+    ADI_EVB_CALLBACK pfAdeSpiRxCallback;
+    /** callback */
+    ADI_EVB_CALLBACK pfAdeSpiTxCallback;
+
+} EVB_SPI_INFO;
+
+/** Spi irq handler */
+static void SpiIrqHandler(void);
+/** Tx dma irq handler */
+static void SpiTxIrqHandler(void);
+/** Rx dma irq handler */
+static void SpiRxIrqHandler(void);
+/** Setup ISRs */
+static void SetupSpiIsr(void);
+/** Evb spi init */
+static int32_t InitAdeSpi(ADI_EVB_SPI_CONFIG *pConfig);
+
+/*=============  D A T A  =============*/
+/** Evb spi info */
+static EVB_SPI_INFO evbSpiInfo;
+
+/*=============  C O D E  =============*/
+
+int32_t EvbInitSpi(void **phSpi, ADI_EVB_SPI_CONFIG *pConfig)
+{
+    int32_t status = 0;
+
+    status = InitAdeSpi(pConfig);
+
+    if (status == 0)
+    {
+        /* Just a keeping a API provision to support multiple SPIs later*/
+        *phSpi = &evbSpiInfo.adeSpiInfo;
+    }
+
+    SetupSpiIsr();
+
+    return status;
+}
+
+int32_t EvbStartAdeSpiTx(void *hEvb, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = -1;
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+    if (hEvb != NULL)
+    {
+        status = MaxStartSpiTxDMA(pSpiInfo, pData, numBytes);
+    }
+
+    return status;
+}
+int32_t EvbStartAdeSpiRx(void *hEvb, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = -1;
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+    if (hEvb != NULL)
+    {
+        status = MaxStartSpiRxDMA(pSpiInfo, pData, numBytes);
+    }
+
+    return status;
+}
+int32_t EvbSetAdeSpiFrequency(void *hEvb, uint32_t spiFrequency)
+{
+    int32_t status = -1;
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+    if (hEvb != NULL)
+    {
+        status = MaxSetSpiFrequency(pSpiInfo, spiFrequency);
+    }
+
+    return status;
+}
+
+int32_t InitAdeSpi(ADI_EVB_SPI_CONFIG *pConfig)
+{
+    int32_t status = 0;
+#if APP_CFG_ENABLE_ADE9178_SPI == 1
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+    int32_t txChannel;
+    int32_t rxChannel;
+    evbSpiInfo.pfAdeSpiRxCallback = pConfig->pfAdeSpiRxCallback;
+    evbSpiInfo.pfAdeSpiTxCallback = pConfig->pfAdeSpiTxCallback;
+    txChannel = MXC_DMA_AcquireChannel();
+    rxChannel = MXC_DMA_AcquireChannel();
+    if ((txChannel < 0) || ((rxChannel < 0)))
+    {
+        status = ADI_EVB_STATUS_DMA_CHANNEL_ACQUIRE_ERROR;
+    }
+    else
+    {
+
+        pSpiInfo->txDmaDesc.channel = txChannel;
+        pSpiInfo->rxDmaDesc.channel = rxChannel;
+        pSpiInfo->numSlaves = 1;
+        pSpiInfo->rxDmaDesc.source = MaxGetSpiDMAReqSelRx(BOARD_CFG_ADE9178_SPI);
+        pSpiInfo->txDmaDesc.source = MaxGetSpiDMAReqSelTx(BOARD_CFG_ADE9178_SPI);
+        pSpiInfo->spiSpeed = APP_CFG_ADE9178_SPI_SPEED;
+        pSpiInfo->pSpi = BOARD_CFG_ADE9178_SPI;
+        pSpiInfo->spiMode = APP_CFG_ADE9178_SPI_MODE;
+        pSpiInfo->master = 1;
+        status = MaxInitSpi(pSpiInfo);
+    }
+
+#endif /* APP_CFG_ENABLE_ADE9178_SPI */
+
+    return status;
+}
+
+void SetupSpiIsr(void)
+{
+    IRQn_Type irqn;
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+
+    /* SPI Isr */
+    irqn = MXC_SPI_GET_IRQ(MXC_SPI_GET_IDX(BOARD_CFG_ADE9178_SPI));
+    NVIC_EnableIRQ(irqn);
+    NVIC_SetVector(irqn, (uint32_t)SpiIrqHandler);
+    NVIC_SetPriority(irqn, APP_CFG_ADE9178_SPI_INT_PRIORITY);
+
+    /* Spi DMA Tx ISR*/
+    irqn = MaxGetDMAIRQn(pSpiInfo->txDmaDesc.channel);
+    NVIC_EnableIRQ(irqn);
+    NVIC_SetPriority(irqn, APP_CFG_ADE9178_SPI_TX_INT_PRIORITY);
+    NVIC_SetVector(irqn, (uint32_t)SpiTxIrqHandler);
+
+    /* Spi DMA Rx ISR*/
+    irqn = MaxGetDMAIRQn(pSpiInfo->rxDmaDesc.channel);
+    NVIC_EnableIRQ(irqn);
+    NVIC_SetVector(irqn, (uint32_t)SpiRxIrqHandler);
+    NVIC_SetPriority(irqn, APP_CFG_ADE9178_SPI_RX_INT_PRIORITY);
+}
+
+void SpiIrqHandler(void)
+{
+    uint32_t intStatus;
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+
+    intStatus = pSpiInfo->pSpi->intfl;
+    pSpiInfo->pSpi->intfl = intStatus; // clearing all pending interrupts(write 1 to clear)
+}
+
+void SpiTxIrqHandler(void)
+{
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+
+    pSpiInfo->txError = 0;
+    /* 0x50 is the mask for timeout and Bus Error bits */
+    if (MXC_DMA->ch[pSpiInfo->txDmaDesc.channel].status & 0x50)
+    {
+        pSpiInfo->txError = 1;
+    }
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[pSpiInfo->txDmaDesc.channel].status |= 0x5C;
+    if (evbSpiInfo.pfAdeSpiTxCallback != NULL)
+    {
+        evbSpiInfo.pfAdeSpiTxCallback();
+    }
+}
+void SpiRxIrqHandler(void)
+{
+    MAX_SPI_INSTANCE *pSpiInfo = &evbSpiInfo.adeSpiInfo;
+
+    pSpiInfo->rxError = 0;
+    /* 0x50 is the mask for timeout and Bus Error bits */
+    if (MXC_DMA->ch[pSpiInfo->rxDmaDesc.channel].status & 0x50)
+    {
+        pSpiInfo->rxError = 1;
+    }
+    if (evbSpiInfo.pfAdeSpiRxCallback != NULL)
+    {
+        evbSpiInfo.pfAdeSpiRxCallback();
+    }
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[pSpiInfo->rxDmaDesc.channel].status |= 0x5C;
+}
+
+/**
+ * @}
+ */

--- a/max/eval_ade9178/source/eval_ade9178_uart.c
+++ b/max/eval_ade9178/source/eval_ade9178_uart.c
@@ -1,0 +1,369 @@
+/******************************************************************************
+ Copyright (c) 2023 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     eval_ade9178_uart.c
+ * @brief    This file contains the routines for initializing,configuring and
+ * staring DMA for receiving waveform samples.
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+
+#include "adi_evb.h"
+#include "app_cfg.h"
+#include "dma.h"
+#include "max3267x_uart_config.h"
+#include "mxc_delay.h"
+#include "nvic_table.h"
+#include "uart.h"
+#include "uart_revb_regs.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+/** Evb uart info */
+typedef struct
+{
+    /** maxim uart info */
+    MAX_UART_INSTANCE wfsUartInfo;
+    /** maxim uart info */
+    MAX_UART_INSTANCE hostUartInfo;
+    /** callback */
+    ADI_EVB_CALLBACK pfWfsRxCallback;
+    /** callback */
+    ADI_EVB_CALLBACK pfHostRxCallback;
+    /** callback */
+    ADI_EVB_CALLBACK pfHostTxCallback;
+
+} EVB_UART_INFO;
+
+/*=============  D A T A  =============*/
+/** Evb uart info */
+static EVB_UART_INFO evbUartInfo;
+static ADI_EVB_CALLBACK pUartRxCallBack;
+/*=============  C O D E  =============*/
+
+#if APP_CFG_ENABLE_WFS_UART == 1
+/** Initialse uart for Wfs */
+static int32_t InitWfsUart(ADI_EVB_UART_CONFIG *pConfig);
+/** Set up uart isr */
+static void SetupWfsUartIsr(void);
+/** Uart rx dma handler */
+static void WfsUartRxDmaIrqHandler(void);
+/** Uart irq handler */
+static void WfsUartIrqHandler(void);
+#endif /* APP_CFG_ENABLE_HOST_UART */
+
+#if APP_CFG_ENABLE_HOST_UART == 1
+/** Uart rx dma handler */
+static void HostUartRxIrqHandler(void);
+/** Uart tx dma handler */
+static void HostUartTxIrqHandler(void);
+/** Initialse uart for host */
+static int32_t InitHostUart(ADI_EVB_UART_CONFIG *pConfig);
+/** Set up uart isr */
+static void SetupHostUartIsr(void);
+static void HostUartRxCallBack(mxc_uart_req_t *req, int result);
+
+#endif /* APP_CFG_ENABLE_HOST_UART */
+
+int32_t EvbInitUart(void **phUart, ADI_EVB_UART_CONFIG *pConfig)
+{
+    int32_t status = 0;
+#if APP_CFG_ENABLE_HOST_UART == 1
+    status = InitHostUart(pConfig);
+#endif /* APP_CFG_ENABLE_HOST_UART */
+#if APP_CFG_ENABLE_WFS_UART == 1
+    if (status == 0)
+    {
+        status = InitWfsUart(pConfig);
+    }
+#endif /* APP_CFG_ENABLE_HOST_UART */
+    if (status == 0)
+    {
+        *phUart = &evbUartInfo;
+    }
+
+    return status;
+}
+
+int32_t EvbStartAdeWfsUartRx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.wfsUartInfo;
+    int32_t status = -1;
+    pUartInfo->isRxComplete = 0;
+    if (hEvb != NULL)
+    {
+        status = MaxStartUartRxDMA(pUartInfo, pBuffer, numBytes);
+    }
+
+    return status;
+}
+
+int32_t EvbSetAdeWfsUartBaudrate(void *hEvb, uint32_t baudRate)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.wfsUartInfo;
+    int32_t status = -1;
+    if (hEvb != NULL)
+    {
+        status = MaxSetUartBaudrate(pUartInfo, baudRate);
+    }
+
+    return status;
+}
+int32_t EvbStartHostUartRx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    int32_t status = -1;
+    pUartInfo->isRxComplete = 0;
+    if (hEvb != NULL)
+    {
+        status = MaxStartUartRx(pUartInfo, pBuffer, numBytes);
+        while (pUartInfo->isRxComplete == 0)
+        {
+        }
+    }
+
+    return status;
+}
+
+int32_t EvbStartHostUartRxAsync(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    int32_t status = -1;
+
+    if (hEvb != NULL)
+    {
+        while (pUartInfo->isRxComplete == 0)
+        {
+        }
+        pUartInfo->isRxComplete = 0;
+        status = MaxStartUartRx(pUartInfo, pBuffer, numBytes);
+    }
+
+    return status;
+}
+
+int32_t EvbStartHostUartTx(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    int32_t status = -1;
+    pUartInfo->isTxComplete = 0;
+    if (hEvb != NULL)
+    {
+        status = MaxStartUartTxDMA(pUartInfo, pBuffer, numBytes);
+        while (pUartInfo->isTxComplete == 0)
+        {
+        }
+    }
+    return status;
+}
+
+int32_t EvbStartHostUartTxAsync(void *hEvb, uint8_t *pBuffer, uint32_t numBytes)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    int32_t status = -1;
+    if (hEvb != NULL)
+    {
+        while (pUartInfo->isTxComplete == 0)
+        {
+        }
+        pUartInfo->isTxComplete = 0;
+        status = MaxStartUartTxDMA(pUartInfo, pBuffer, numBytes);
+    }
+
+    return status;
+}
+
+int32_t EvbPutBufferNb(uint8_t *pBuffer, uint32_t numBytes)
+{
+    int32_t status;
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    status = EvbStartHostUartTxAsync((void *)pUartInfo, pBuffer, numBytes);
+    // FIXME : Without delay control sequences are displaying in raw message.
+    MXC_Delay(MXC_DELAY_MSEC(1));
+    return status;
+}
+
+int32_t EvbPutBuffer(uint8_t *pBuffer, uint32_t numBytes)
+{
+    int32_t status;
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+
+    status = EvbStartHostUartTx((void *)pUartInfo, pBuffer, numBytes);
+    // FIXME : Without delay control sequences are displaying in raw message.
+    MXC_Delay(MXC_DELAY_MSEC(1));
+    return status;
+}
+
+int32_t EvbGetTxStatus()
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+
+    return (int32_t)pUartInfo->isTxComplete;
+}
+
+#if APP_CFG_ENABLE_HOST_UART == 1
+int32_t InitHostUart(ADI_EVB_UART_CONFIG *pConfig)
+{
+    int32_t status = 0;
+    int32_t channel;
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    pUartInfo->isTxComplete = 1;
+    pUartInfo->isRxComplete = 1;
+    evbUartInfo.pfHostRxCallback = pConfig->pfHostUartRxCallback;
+    evbUartInfo.pfHostTxCallback = pConfig->pfHostUartTxCallback;
+
+    channel = MXC_DMA_AcquireChannel();
+    if (channel < 0)
+    {
+        status = ADI_EVB_STATUS_DMA_CHANNEL_ACQUIRE_ERROR;
+    }
+    else
+    {
+        pUartInfo->txDmaDesc.channel = channel;
+        pUartInfo->rxDmaDesc.channel = (uint32_t)NULL;
+        pUartInfo->rxDmaDesc.source = (uint32_t)NULL;
+        pUartInfo->txDmaDesc.source = MaxGetUartDMAReqSelTx(BOARD_CFG_HOST_UART);
+        pUartInfo->baudrate = APP_CFG_HOST_UART_SPEED;
+        pUartInfo->pUart = BOARD_CFG_HOST_UART;
+        pUartRxCallBack = pConfig->pfHostUartRxCallback;
+        pUartInfo->pfRxCallback = HostUartRxCallBack;
+
+        SetupHostUartIsr();
+        status = MaxInitUart(pUartInfo);
+    }
+    return status;
+}
+
+void SetupHostUartIsr(void)
+{
+    IRQn_Type irqn;
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+
+    /* uart Isr */
+    irqn = MXC_UART_GET_IRQ(MXC_UART_GET_IDX(BOARD_CFG_HOST_UART));
+    NVIC_SetVector(irqn, (uint32_t)HostUartRxIrqHandler);
+    NVIC_SetPriority(irqn, APP_CFG_UART_INTR_PRIORITY);
+    NVIC_EnableIRQ(irqn);
+
+    /* uart DMA Tx ISR*/
+    irqn = MaxGetDMAIRQn(pUartInfo->txDmaDesc.channel);
+    NVIC_SetPriority(irqn, APP_CFG_UART_INTR_PRIORITY);
+    NVIC_SetVector(irqn, (uint32_t)HostUartTxIrqHandler);
+    NVIC_EnableIRQ(irqn);
+}
+
+void HostUartRxIrqHandler(void)
+{
+    MXC_UART_AsyncHandler(BOARD_CFG_HOST_UART);
+}
+
+void HostUartTxIrqHandler(void)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    MXC_DMA_Handler();
+    pUartInfo->isTxComplete = 1;
+    if (evbUartInfo.pfHostTxCallback != NULL)
+    {
+        evbUartInfo.pfHostTxCallback();
+    }
+}
+void HostUartRxCallBack(mxc_uart_req_t *req, int result)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.hostUartInfo;
+    pUartInfo->isRxComplete = 1;
+    // Added code to resolve warning
+    if (req != NULL && result != 0)
+    {
+    }
+
+    pUartRxCallBack();
+}
+
+#endif /* APP_CFG_ENABLE_HOST_UART */
+
+#if APP_CFG_ENABLE_WFS_UART == 1
+int32_t InitWfsUart(ADI_EVB_UART_CONFIG *pConfig)
+{
+    int32_t status = 0;
+    int32_t channel;
+
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.wfsUartInfo;
+    evbUartInfo.pfWfsRxCallback = pConfig->pfWfsUartRxCallback;
+    channel = MXC_DMA_AcquireChannel();
+    if (channel < 0)
+    {
+        status = ADI_EVB_STATUS_DMA_CHANNEL_ACQUIRE_ERROR;
+    }
+    else
+    {
+        pUartInfo->rxDmaDesc.channel = channel;
+        pUartInfo->txDmaDesc.channel = (uint32_t)NULL;
+        pUartInfo->rxDmaDesc.source = MaxGetUartDMAReqSelRx(BOARD_CFG_WFS_UART);
+        pUartInfo->txDmaDesc.source = (uint32_t)NULL;
+        pUartInfo->baudrate = 115200;
+        pUartInfo->pUart = BOARD_CFG_WFS_UART;
+
+        status = MaxInitUart(pUartInfo);
+
+        SetupWfsUartIsr();
+    }
+    return status;
+}
+
+void SetupWfsUartIsr(void)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.wfsUartInfo;
+    int32_t uartIndex;
+    IRQn_Type irqn;
+    uartIndex = MXC_UART_GET_IDX(BOARD_CFG_WFS_UART);
+    /* SPI Isr */
+    irqn = MXC_UART_GET_IRQ(uartIndex);
+    NVIC_SetVector(irqn, (uint32_t)WfsUartIrqHandler);
+    NVIC_SetPriority(irqn, APP_CFG_WFS_ERROR_INT_PRIORITY);
+    NVIC_EnableIRQ(irqn);
+
+    /* Spi DMA Tx ISR*/
+    irqn = MaxGetDMAIRQn(pUartInfo->rxDmaDesc.channel);
+    NVIC_SetPriority(irqn, APP_CFG_WFS_UART_INT_PRIORITY);
+    NVIC_SetVector(irqn, (uint32_t)WfsUartRxDmaIrqHandler);
+    NVIC_EnableIRQ(irqn);
+}
+
+void WfsUartIrqHandler(void)
+{
+    uint32_t intrpStatus;
+
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.wfsUartInfo;
+
+    intrpStatus = pUartInfo->pUart->int_fl;
+    pUartInfo->pUart->int_fl = intrpStatus; // clearing all pending interrupts(write 1 to clear)
+}
+
+void WfsUartRxDmaIrqHandler(void)
+{
+    MAX_UART_INSTANCE *pUartInfo = &evbUartInfo.wfsUartInfo;
+    MAX_DMA_DESC *pDesc = &pUartInfo->rxDmaDesc;
+    pUartInfo->isRxComplete = 1;
+    pUartInfo->rxError = 0;
+    /* 0x50 is the mask for timeout and Bus Error bits */
+    if (MXC_DMA->ch[pDesc->channel].status & 0x50)
+    {
+        pUartInfo->rxError = 1;
+    }
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[pDesc->channel].status |= 0x5C;
+    if (evbUartInfo.pfWfsRxCallback != NULL)
+    {
+        evbUartInfo.pfWfsRxCallback();
+    }
+}
+#endif /* APP_CFG_ENABLE_WFS_UART */
+
+/**
+ * @}
+ */

--- a/max/include/max3267x_dma_config.h
+++ b/max/include/max3267x_dma_config.h
@@ -1,0 +1,92 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file        max3267x_dma_config.h
+ * @brief      User defined Dma APIs for max3267x platform
+ * @addtogroup SPI drivers
+ * @{
+ */
+
+#ifndef __MAX3267X_DMA_CONFIG__
+#define __MAX3267X_DMA_CONFIG__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============= I N C L U D E S =============*/
+#include "dma.h"
+#include "spi.h"
+#include "uart.h"
+#include <stdint.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+/** DMA channel info */
+typedef struct
+{
+    /** ctrl */
+    uint32_t ctrl;
+    /** channel */
+    int32_t channel;
+    /** type of dma request */
+    uint32_t source;
+    /** pointer to data to transfer */
+    uint8_t *pMem;
+    /** num of bytes */
+    uint32_t numBytes;
+
+} MAX_DMA_DESC;
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+/**
+ * @brief Gets the IRQn for a DMA channel
+ * @param channel - DMA channel
+ * @return IRQn of the selected DMA channel
+ */
+IRQn_Type MaxGetDMAIRQn(int channel);
+
+/**
+ * @brief Enables dma channel
+ * @param pDesc - pointer to dma channel info struct
+ */
+void MaxEnableDMAChannel(MAX_DMA_DESC *pDesc);
+
+/**
+ * @brief Gets request type of spi
+ * @param pSpi - pointer to spi registers
+ * @return request type
+ */
+mxc_dma_reqsel_t MaxGetSpiDMAReqSelRx(mxc_spi_regs_t *pSpi);
+
+/**
+ * @brief Gets request type for uart
+ * @param pSpi - pointer to spi registers
+ * @return request type
+ */
+mxc_dma_reqsel_t MaxGetUartDMAReqSelRx(mxc_uart_regs_t *pSpi);
+
+/**
+ * @brief Gets request type for spi dma
+ * @param pSpi - pointer to spi registers
+ * @return request type
+ */
+mxc_dma_reqsel_t MaxGetSpiDMAReqSelTx(mxc_spi_regs_t *pSpi);
+
+/**
+ * @brief Gets request type for uart dma
+ * @param pSpi - pointer to spi registers
+ * @return request type
+ */
+mxc_dma_reqsel_t MaxGetUartDMAReqSelTx(mxc_uart_regs_t *pSpi);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MAX3267X_DMA_CONFIG__ */
+
+/**
+ * @}
+ */

--- a/max/include/max3267x_spi_config.h
+++ b/max/include/max3267x_spi_config.h
@@ -1,0 +1,145 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file  max3267x_spi_config.h
+ * @brief User defined SPI APIs for max3267x platform
+ * @defgroup    SPI drivers
+ * @{
+ */
+
+#ifndef __MAX3267X_SPI_CONFIG_H__
+#define __MAX3267X_SPI_CONFIG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============= I N C L U D E S =============*/
+#include "max3267x_dma_config.h"
+#include "spi.h"
+#include <stdint.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+/**
+ * @brief Maxim SPI instance info
+ */
+typedef struct
+{
+    /** Dummy command buffer is required during transmit and receive spi dma */
+    uint32_t dummyCmd;
+    /** rx dma channel */
+    MAX_DMA_DESC rxDmaDesc;
+    /** tx dma channel */
+    MAX_DMA_DESC txDmaDesc;
+    /** pointer to spi registers struct */
+    mxc_spi_regs_t *pSpi;
+    /** spi speed */
+    uint32_t spiSpeed;
+    /** no of slaves */
+    uint8_t numSlaves;
+    /** master or slave mode */
+    uint8_t master;
+    /** spi mode */
+    uint8_t spiMode;
+    /** slave index */
+    uint8_t slaveIndex;
+    /** flag for rx complete*/
+    volatile uint8_t isRxComplete;
+    /** flag for tx complete*/
+    volatile uint8_t isTxComplete;
+    /** flag for tx error*/
+    volatile uint8_t txError;
+    /** flag for rx error*/
+    volatile uint8_t rxError;
+    /** suspenState is used to suspend from the blocking state */
+    volatile uint8_t suspendState;
+
+} MAX_SPI_INSTANCE;
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+/**
+ * @brief Initialses Master SPI
+ * @param[in]  pSpiInfo  - pointer to the spi info struct
+ * @return  error or success
+ */
+int32_t MaxInitSpi(MAX_SPI_INSTANCE *pSpiInfo);
+
+/**
+ * @brief SPI Master Tx API
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @param[in]  pData  - pointer to Tx data
+ * @param[in]  numBytes  - num of bytes to send
+ * @return  error or success
+ */
+int32_t MaxStartSpiTxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief SPI Master Rx API
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @param[in]  pData  - pointer to Tx data
+ * @param[in]  numBytes  - num of bytes to send
+ * @return  error or success
+ */
+int32_t MaxStartSpiRxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief SPI Set frequency
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @param[in]  spiFrequency  - spi frequency in Hz
+ * @return  error or success
+ */
+int32_t MaxSetSpiFrequency(MAX_SPI_INSTANCE *pSpiInfo, uint32_t spiFrequency);
+
+/**
+ * @brief SPI clear interrupt
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ */
+void MaxClearSpiInterrupt(MAX_SPI_INSTANCE *pSpiInfo);
+
+/**
+ * @brief SPI Slave Init
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @return  error or success
+ */
+int32_t MaxSlaveInitSpi(MAX_SPI_INSTANCE *pSpiInfo);
+
+/**
+ * @brief SPI Slave Tx API
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @param[in]  pData  - pointer to Tx data
+ * @param[in]  numBytes  - num of bytes to send
+ * @return  error or success
+ */
+int32_t MaxSlaveStartSpiTxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief SPI Slave Rx API
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @param[in]  pData  - pointer to Rx data
+ * @param[in]  numBytes  - num of bytes to send
+ * @return  error or success
+ */
+int32_t MaxSlaveStartSpiRxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief SPI Master Tx Rx API
+ * @param[in]  pSpiInfo  - pointer to the spi info
+ * @param[in]  pTxData  - pointer to Tx data
+ * @param[in]  pRxData  - pointer to Rx data
+ * @param[in]  numBytes  - num of bytes to send
+ * @return  error or success
+ */
+int32_t MaxStartSpiTxRxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pTxData, uint8_t *pRxData,
+                           uint32_t numBytes);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MAX3267X_SPI_CONFIG_H__ */
+
+/**
+ * @}
+ */

--- a/max/include/max3267x_timer_config.h
+++ b/max/include/max3267x_timer_config.h
@@ -1,0 +1,63 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file  max3267x_timer_config.h
+ * @brief User defined Timer APIs for max3267x platform
+ * @defgroup    SPI drivers
+ * @{
+ */
+
+#ifndef __MAX3267X_TIMER_H__
+#define __MAX3267X_TIMER_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============= I N C L U D E S =============*/
+#include "tmr.h"
+#include <stdint.h>
+
+/**
+ * @brief Initialses Timer
+ * @param[in]  pTmr  - pointer to timer registers
+ * @return  error or success
+ */
+int32_t MaxTimerInit(mxc_tmr_regs_t *pTmr);
+
+/**
+ * @brief Gets Timer valu
+ * @param[in]  pTmr  - pointer to timer registers
+ * @return  error or success
+ */
+uint32_t MaxGetTime(mxc_tmr_regs_t *pTmr);
+
+/**
+ * @brief Gets Maximum Timer value
+ * @return  error or success
+ */
+uint32_t MaxGetMaximumTime();
+
+/**
+ * @brief Starts Timer
+ * @param[in]  pTmr  - pointer to timer registers
+ */
+void MaxStartTimer(mxc_tmr_regs_t *pTmr);
+
+/**
+ * @brief Stops Timer
+ * @param[in]  pTmr  - pointer to timer registers
+ */
+void MaxStopTimer(mxc_tmr_regs_t *pTmr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MAX3267X_TIMER_H__ */
+
+/**
+ * @}
+ */

--- a/max/include/max3267x_uart_config.h
+++ b/max/include/max3267x_uart_config.h
@@ -1,0 +1,99 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file  max3267x_uart_config.h
+ * @brief User defined Uart APIs for max3267x platform
+ * @defgroup    SPI drivers
+ * @{
+ */
+
+#ifndef __MAX3267X_UART_CONFIG__
+#define __MAX3267X_UART_CONFIG__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============= I N C L U D E S =============*/
+#include "max3267x_dma_config.h"
+#include "uart.h"
+#include <stdint.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+/** Maxim uart instance info*/
+typedef struct
+{
+    /** Rx dma channel */
+    MAX_DMA_DESC rxDmaDesc;
+    /** Tx dma channel */
+    MAX_DMA_DESC txDmaDesc;
+    /** Uart registers */
+    mxc_uart_regs_t *pUart;
+    /** baud rate */
+    uint32_t baudrate;
+    /** Rx dma call back */
+    mxc_uart_complete_cb_t pfRxCallback;
+    /** rx complete flag */
+    volatile uint8_t isRxComplete;
+    /** Tx complete flag */
+    volatile uint8_t isTxComplete;
+    /** tx error flag*/
+    volatile uint8_t txError;
+    /** rx error flag*/
+    volatile uint8_t rxError;
+} MAX_UART_INSTANCE;
+
+/*======= P U B L I C   P R O T O T Y P E S ========*/
+/**
+ * @brief Initialses uart
+ * @param[in]  pUartInfo  - pointer to the uart info struct
+ * @return  error or success
+ */
+int32_t MaxInitUart(MAX_UART_INSTANCE *pUartInfo);
+
+/**
+ * @brief Start Uart Tx
+ * @param[in]  pUartInfo  - pointer to the uart info struct
+ * @param[in] pData - pointer to data
+ * @param[in] numBytes - num of bytes
+ * @return  error or success
+ */
+int32_t MaxStartUartTxDMA(MAX_UART_INSTANCE *pUartInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief Start Uart rx
+ * @param[in]  pUartInfo  - pointer to the uart info struct
+ * @param[in] pData - pointer to data
+ * @param[in] numBytes - num of bytes
+ * @return  error or success
+ */
+int32_t MaxStartUartRx(MAX_UART_INSTANCE *pUartInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief Start Uart rx
+ * @param[in]  pUartInfo  - pointer to the uart info struct
+ * @param[in] pData - pointer to data
+ * @param[in] numBytes - num of bytes
+ * @return  error or success
+ */
+int32_t MaxStartUartRxDMA(MAX_UART_INSTANCE *pUartInfo, uint8_t *pData, uint32_t numBytes);
+
+/**
+ * @brief Set baudrate for uart
+ * @param[in]  pUartInfo  - pointer to the uart info struct
+ * @param[in] baudRate - baudrate
+ * @return  error or success
+ */
+int32_t MaxSetUartBaudrate(MAX_UART_INSTANCE *pUartInfo, uint32_t baudRate);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __MAX3267X_UART_CONFIG__ */
+
+/**
+ * @}
+ */

--- a/max/source/max3267x_crc_config.c
+++ b/max/source/max3267x_crc_config.c
@@ -1,0 +1,325 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     max3267x_crc_config.c
+ * @brief    This file contains the routines for initializing and calculating
+ *           CRC value using MAX32670 CRC Module.
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+#include "adi_crc.h"
+#include "adi_crc_cfg.h"
+#include "adi_crc_hw.h"
+#include "adi_evb.h"
+#include "app_cfg.h"
+#include "crc.h"
+#include "dma.h"
+#include "dma_reva.h"
+#include "max32670.h"
+#include "max3267x_dma_config.h"
+#include "nvic_table.h"
+#include <crc_reva.h>
+#include <crc_reva_regs.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+/*=============  D E F I N I T I O N S  =============*/
+
+/**
+ * @brief Crc info struct for max32670
+ */
+typedef struct
+{
+    /** CRC Handle */
+    ADI_CRC_HANDLE hCrc;
+    /** lock crc */
+    uint8_t lock;
+    /** dma channel reserved for CRC */
+    uint8_t dmaChannel;
+    /** dma error flag */
+    uint8_t dmaError;
+    /** variable to check status of CRC transaction*/
+    volatile bool isComplete;
+    /** CRC output */
+    uint32_t crc;
+    /** crc request struct */
+    mxc_crc_req_t crcReq;
+
+} CRC_HW_INFO;
+
+/*=============  D A T A  =============*/
+
+static CRC_HW_INFO crcHw;
+
+/*============= F U N C T I O N S =============*/
+
+static ADI_CRC_RESULT CrcSetConfig(ADI_CRC_DATA *pData);
+
+static ADI_CRC_RESULT ConfigCrcDma(mxc_crc_reva_req_t *pReq);
+
+static int32_t SetupCrcDma(uint8_t dmaChannel);
+
+static void CrcDmaIrqHandler(void);
+
+static void CrcDmaCallBack(int ch, int error);
+
+static ADI_CRC_RESULT FormatSeed(ADI_CRC_CONFIG *pCrcConfig);
+
+static ADI_CRC_RESULT FormatResult(volatile ADI_CRC_CONFIG *pCrcConfig, volatile uint32_t *pData);
+
+/*=============  C O D E  =============*/
+
+ADI_CRC_RESULT EvbInitCrc(void **phCrc)
+{
+    ADI_CRC_RESULT status = ADI_CRC_RESULT_SUCCESS;
+    crcHw.hCrc = *phCrc;
+    crcHw.dmaChannel = (uint8_t)MXC_DMA_AcquireChannel();
+    status = SetupCrcDma(crcHw.dmaChannel);
+
+    MXC_CRC_Init();
+
+    return status;
+}
+
+int32_t EvbCrcSetConfig(ADI_CRC_DATA *pData)
+{
+    int32_t status = 0;
+    uint32_t crcBuff = 0x00;
+    status = FormatSeed(&pData->crcCfg);
+    if (status == 0)
+    {
+        if (pData->crcCfg.poly != 0u)
+        {
+            MXC_CRC->ctrl |=
+                (uint32_t)((pData->crcCfg.reversed << 3) | (pData->crcCfg.bigEndian << 2));
+            // Load CRC polynomial into crc polynomial register
+            MXC_CRC_SetPoly((uint32_t)pData->crcCfg.poly << 16);
+            crcHw.crcReq.dataBuffer = &crcBuff;
+            crcHw.crcReq.dataLen = 1;
+            // Initialises the DMA and CRC. Refer section 15.5 of MAX32670 user
+            // guide.
+            status = ConfigCrcDma((mxc_crc_reva_req_t *)&crcHw.crcReq);
+        }
+    }
+    else
+    {
+        status = ADI_CRC_RESULT_FAILURE;
+    }
+
+    return status;
+}
+
+void EvbCalculateCrc(ADI_CRC_DATA *pCrcData, uint8_t *pData, uint16_t offset, uint32_t numBytes)
+{
+    crcHw.isComplete = false;
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[crcHw.dmaChannel].status |= 0x5C;
+    MXC_CRC->ctrl |= MXC_F_CRC_CTRL_EN;
+    MXC_CRC->val = pCrcData->crcCfg.seed;
+    /* Set start address and initiate DMA*/
+    MXC_DMA->ch[crcHw.dmaChannel].src = (unsigned int)(pData + offset);
+    MXC_DMA->ch[crcHw.dmaChannel].cnt = numBytes;
+    MXC_DMA->ch[crcHw.dmaChannel].ctrl |= (MXC_F_DMA_CTRL_EN | MXC_F_DMA_CTRL_CTZ_IE);
+}
+
+ADI_CRC_RESULT EvbGetCrc(ADI_CRC_HANDLE hCrc, uint32_t *pData)
+{
+    ADI_CRC_RESULT status = ADI_CRC_RESULT_SUCCESS;
+    volatile ADI_CRC_DATA *pCrcData = (ADI_CRC_DATA *)hCrc;
+
+    if (crcHw.dmaError == 1)
+    {
+        status = ADI_CRC_RESULT_RUN_TIME_ERROR;
+        crcHw.dmaError = 0;
+    }
+    else if (crcHw.isComplete == true)
+    {
+        *pData = pCrcData->crcValue;
+        status = FormatResult(&pCrcData->crcCfg, pData);
+    }
+    else
+    {
+        *pData = 0xFFFFFFFF;
+        status = ADI_CRC_RESULT_NOT_READY;
+    }
+    return status;
+}
+
+static int32_t SetupCrcDma(uint8_t dmaChannel)
+{
+    ADI_CRC_RESULT status = ADI_CRC_RESULT_SUCCESS;
+    IRQn_Type dmaChannelIRQn;
+
+    dmaChannelIRQn = MaxGetDMAIRQn(dmaChannel);
+    if (dmaChannelIRQn != MXC_IRQ_EXT_COUNT)
+    {
+        NVIC_SetPriority(dmaChannelIRQn, ADI_CRC_CFG_DMA_INT_PRIORITY);
+        NVIC_SetVector(dmaChannelIRQn, (uint32_t)CrcDmaIrqHandler);
+        NVIC_EnableIRQ(dmaChannelIRQn);
+    }
+    else
+    {
+        /* Acquired DMA Channel is not in the range of 0 to 8*/
+        status = ADI_CRC_RESULT_INIT_FAILURE;
+    }
+    return status;
+}
+
+static void CrcDmaIrqHandler(void)
+{
+
+    /* 0x50 is the mask for timeout and Bus Error bits */
+    if (MXC_DMA->ch[crcHw.dmaChannel].status & 0x50)
+    {
+        crcHw.dmaError = true;
+    }
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[crcHw.dmaChannel].status |= 0x5C;
+    CrcDmaCallBack(crcHw.dmaChannel, 0);
+}
+
+void EvbResetHw(void)
+{
+
+    MXC_CRC->ctrl &= ~MXC_F_CRC_CTRL_EN;
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[crcHw.dmaChannel].status |= 0x5C;
+}
+
+void EvbCrcClearInterrupt(void)
+{
+    MXC_CRC->ctrl &= ~MXC_F_CRC_CTRL_EN;
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[crcHw.dmaChannel].status |= 0x5C;
+}
+
+static ADI_CRC_RESULT ConfigCrcDma(mxc_crc_reva_req_t *pReq)
+{
+    ADI_CRC_RESULT status = ADI_CRC_RESULT_SUCCESS;
+    mxc_dma_config_t config;
+    mxc_dma_srcdst_t srcdst;
+
+    if ((pReq == NULL) || (pReq->dataBuffer == NULL))
+    {
+        status = ADI_CRC_RESULT_NULL_PTR;
+    }
+
+    if (status == ADI_CRC_RESULT_SUCCESS)
+    {
+        if (pReq->dataLen == 0)
+        {
+            status = ADI_CRC_RESULT_INIT_FAILURE;
+        }
+    }
+
+    if (status == ADI_CRC_RESULT_SUCCESS)
+    {
+
+        config.reqsel = MXC_DMA_REQUEST_CRCTX;
+
+        config.ch = crcHw.dmaChannel;
+
+        config.srcwd = MXC_DMA_WIDTH_BYTE;
+        config.dstwd = MXC_DMA_WIDTH_BYTE;
+
+        config.srcinc_en = 1;
+        config.dstinc_en = 0;
+
+        srcdst.ch = crcHw.dmaChannel;
+        srcdst.source = (uint8_t *)pReq->dataBuffer; // transfering bytes
+        srcdst.len = (int)(pReq->dataLen * 4);       // number of bytes
+        srcdst.dest = NULL;
+
+        MXC_CRC->ctrl |= MXC_F_CRC_CTRL_DMA_EN;
+        MXC_CRC->ctrl |= MXC_F_CRC_CTRL_EN;
+
+        MXC_DMA_ConfigChannel(config, srcdst);
+        MXC_DMA_SetCallback(crcHw.dmaChannel, NULL);
+        MXC_DMA_EnableInt(crcHw.dmaChannel);
+    }
+    return status;
+}
+
+static void CrcDmaCallBack(int ch, int error)
+{
+    ADI_CRC_DATA *pCrcData = (ADI_CRC_DATA *)crcHw.hCrc;
+    int32_t waitCount = 0;
+    int32_t timeOutCount = ADI_CRC_CFG_TIMEOUT_COUNT;
+    while (((MXC_CRC->ctrl >> MXC_F_CRC_CTRL_BUSY_POS) & 1) && (waitCount < timeOutCount))
+    {
+        // Wait for the crc computation to complete
+        waitCount++;
+    }
+    if ((error == E_NO_ERROR) && (ch == crcHw.dmaChannel) && (waitCount < timeOutCount))
+    {
+        pCrcData->crcValue = MXC_CRC->val;
+    }
+    MXC_CRC->ctrl &= ~MXC_F_CRC_CTRL_EN;
+    crcHw.isComplete = true;
+    if (pCrcData->crcCfg.pfCallback != NULL)
+    {
+        pCrcData->crcCfg.pfCallback(pCrcData->crcCfg.pCBData);
+    }
+}
+
+static ADI_CRC_RESULT FormatSeed(ADI_CRC_CONFIG *pCrcConfig)
+{
+
+    ADI_CRC_RESULT status = ADI_CRC_RESULT_SUCCESS;
+
+    // Format the initial value.
+    if ((pCrcConfig->crcType == ADI_CRC_TYPE_CRC8) && (pCrcConfig->bigEndian == true))
+    {
+        pCrcConfig->seed = (uint32_t)(pCrcConfig->seed << 24);
+    }
+    else if ((pCrcConfig->crcType == ADI_CRC_TYPE_CRC16) && (pCrcConfig->bigEndian == true))
+    {
+        pCrcConfig->seed = (uint32_t)(pCrcConfig->seed << 16);
+    }
+    else if ((pCrcConfig->crcType == ADI_CRC_TYPE_CRC32) && (pCrcConfig->bigEndian == true))
+    {
+        // No change to initial value
+        pCrcConfig->seed = (uint32_t)(pCrcConfig->seed);
+    }
+    else
+    {
+        // Other case needs to considered in future.
+        status = ADI_CRC_RESULT_FAILURE;
+    }
+
+    return status;
+}
+
+static ADI_CRC_RESULT FormatResult(volatile ADI_CRC_CONFIG *pCrcConfig, volatile uint32_t *pData)
+{
+    ADI_CRC_RESULT status = ADI_CRC_RESULT_SUCCESS;
+
+    // Format the CRC result.
+    if ((pCrcConfig->crcType == ADI_CRC_TYPE_CRC8) && (pCrcConfig->bigEndian == true))
+    {
+        *pData = (uint32_t)(*pData >> 24);
+    }
+    else if ((pCrcConfig->crcType == ADI_CRC_TYPE_CRC16) && (pCrcConfig->bigEndian == true))
+    {
+        *pData = (uint32_t)(*pData >> 16);
+    }
+    else if ((pCrcConfig->crcType == ADI_CRC_TYPE_CRC32) && (pCrcConfig->bigEndian == true))
+    {
+        // No change to initial value
+        *pData = (uint32_t)*pData;
+    }
+    else
+    {
+        // Other case needs to considered in future.
+        status = ADI_CRC_RESULT_FAILURE;
+    }
+
+    return status;
+}
+
+/**
+ * @}
+ */

--- a/max/source/max3267x_dma_config.c
+++ b/max/source/max3267x_dma_config.c
@@ -1,0 +1,178 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     max3267x_dma_config.c
+ * @brief    User defined Dma APIs for max3267x platform
+ * the protocol.
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+#include "max3267x_dma_config.h"
+#include "mxc_device.h"
+#include <stdint.h>
+/*=============  D A T A  =============*/
+
+/*=============  D E F I N I T I O N S  =============*/
+
+/*=============  C O D E  =============*/
+
+void MaxEnableDMAChannel(MAX_DMA_DESC *pDesc)
+{
+    MXC_DMA->ch[pDesc->channel].ctrl &= ~(MXC_F_DMA_CTRL_EN | MXC_F_DMA_CTRL_CTZ_IE);
+    MXC_DMA->ch[pDesc->channel].ctrl = pDesc->ctrl;
+    /* We are good assigning both as src is ignored for Rx channel
+         and dst is ignored for Tx channel */
+    MXC_DMA->ch[pDesc->channel].src = (unsigned int)(pDesc->pMem);
+    MXC_DMA->ch[pDesc->channel].dst = (unsigned int)(pDesc->pMem);
+    MXC_DMA->ch[pDesc->channel].cnt = pDesc->numBytes;
+    MXC_DMA->ch[pDesc->channel].ctrl |= (MXC_F_DMA_CTRL_EN | MXC_F_DMA_CTRL_CTZ_IE);
+}
+
+IRQn_Type MaxGetDMAIRQn(int channel)
+{
+    IRQn_Type irqN;
+    switch (channel)
+    {
+    case 0:
+        irqN = DMA0_IRQn;
+        break;
+    case 1:
+        irqN = DMA1_IRQn;
+        break;
+    case 2:
+        irqN = DMA2_IRQn;
+        break;
+    case 3:
+        irqN = DMA3_IRQn;
+        break;
+    case 4:
+        irqN = DMA4_IRQn;
+        break;
+    case 5:
+        irqN = DMA5_IRQn;
+        break;
+    case 6:
+        irqN = DMA6_IRQn;
+        break;
+    case 7:
+        irqN = DMA7_IRQn;
+        break;
+    default:
+        irqN = MXC_IRQ_EXT_COUNT;
+        break;
+    }
+    return irqN;
+}
+
+mxc_dma_reqsel_t MaxGetSpiDMAReqSelRx(mxc_spi_regs_t *pSpi)
+{
+    int32_t spiNum;
+    mxc_dma_reqsel_t reqSel;
+    spiNum = MXC_SPI_GET_IDX(pSpi);
+    switch (spiNum)
+    {
+    case 0:
+        reqSel = MXC_DMA_REQUEST_SPI0RX;
+        break;
+
+    case 1:
+        reqSel = MXC_DMA_REQUEST_SPI1RX;
+        break;
+
+    case 2:
+        reqSel = MXC_DMA_REQUEST_SPI2RX;
+        break;
+
+    default:
+        reqSel = MXC_DMA_REQUEST_SPI0RX;
+        break;
+    }
+
+    return reqSel;
+}
+
+mxc_dma_reqsel_t MaxGetUartDMAReqSelRx(mxc_uart_regs_t *pUart)
+{
+    int32_t uartNum;
+    mxc_dma_reqsel_t reqSel;
+    uartNum = MXC_UART_GET_IDX(pUart);
+    switch (uartNum)
+    {
+    case 0:
+        reqSel = MXC_DMA_REQUEST_UART0RX;
+        break;
+
+    case 1:
+        reqSel = MXC_DMA_REQUEST_UART1RX;
+        break;
+
+    case 2:
+        reqSel = MXC_DMA_REQUEST_UART2RX;
+        break;
+    default:
+        reqSel = MXC_DMA_REQUEST_UART0RX;
+        break;
+    }
+
+    return reqSel;
+}
+
+mxc_dma_reqsel_t MaxGetSpiDMAReqSelTx(mxc_spi_regs_t *pSpi)
+{
+    int32_t spiNum;
+    mxc_dma_reqsel_t reqSel;
+    spiNum = MXC_SPI_GET_IDX(pSpi);
+    switch (spiNum)
+    {
+    case 0:
+        reqSel = MXC_DMA_REQUEST_SPI0TX;
+        break;
+
+    case 1:
+        reqSel = MXC_DMA_REQUEST_SPI1TX;
+        break;
+
+    case 2:
+        reqSel = MXC_DMA_REQUEST_SPI2TX;
+        break;
+
+    default:
+        reqSel = MXC_DMA_REQUEST_SPI0TX;
+        break;
+    }
+
+    return reqSel;
+}
+
+mxc_dma_reqsel_t MaxGetUartDMAReqSelTx(mxc_uart_regs_t *pUart)
+{
+    int32_t uartNum;
+    mxc_dma_reqsel_t reqSel;
+    uartNum = MXC_UART_GET_IDX(pUart);
+    switch (uartNum)
+    {
+    case 0:
+        reqSel = MXC_DMA_REQUEST_UART0TX;
+        break;
+
+    case 1:
+        reqSel = MXC_DMA_REQUEST_UART1TX;
+        break;
+
+    case 2:
+        reqSel = MXC_DMA_REQUEST_UART2TX;
+        break;
+    default:
+        reqSel = MXC_DMA_REQUEST_UART0TX;
+        break;
+    }
+
+    return reqSel;
+}
+
+/**
+ * @}
+ */

--- a/max/source/max3267x_spi_config.c
+++ b/max/source/max3267x_spi_config.c
@@ -1,0 +1,267 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     max3267x_spi_config.c
+ * @brief    SPI configuration
+ * @{
+ */
+
+/*============= I N C L U D E S =============*/
+#include "max3267x_spi_config.h"
+#include "dma.h"
+#include "nvic_table.h"
+#include "spi.h"
+#include <stdint.h>
+#include <stdio.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+/** Initialise Spi */
+static void InitSpi(void *pSpi, uint32_t master);
+/** Start Spi Dma*/
+static void StartSpiDMA(void *pSpi, MAX_DMA_DESC *pRx, MAX_DMA_DESC *pTx, uint32_t targetSelect);
+
+/*=============  C O D E  =============*/
+int32_t MaxInitSpi(MAX_SPI_INSTANCE *pSpiInfo)
+{
+    int32_t status = 0;
+
+    pSpiInfo->pSpi->ctrl0 &= ~(MXC_F_SPI_CTRL0_EN);
+
+    status = MXC_SPI_Init(pSpiInfo->pSpi, pSpiInfo->master, 0, pSpiInfo->numSlaves, 0,
+                          pSpiInfo->spiSpeed);
+    MXC_SPI_SetDataSize(pSpiInfo->pSpi, 8);
+    if (status == 0)
+    {
+        status = MXC_SPI_SetWidth(pSpiInfo->pSpi, SPI_WIDTH_STANDARD);
+    }
+    if (status == 0)
+    {
+        status = MXC_SPI_SetMode(pSpiInfo->pSpi, pSpiInfo->spiMode);
+    }
+    if (status == 0)
+    {
+        MXC_SPI_SetTXThreshold(pSpiInfo->pSpi, 4);
+        MXC_SPI_SetRXThreshold(pSpiInfo->pSpi, 0);
+    }
+
+    InitSpi(pSpiInfo->pSpi, pSpiInfo->master);
+    MXC_DMA->inten |= ((1 << pSpiInfo->txDmaDesc.channel) | (1 << pSpiInfo->rxDmaDesc.channel));
+    return status;
+}
+
+int32_t MaxSlaveInitSpi(MAX_SPI_INSTANCE *pSpiInfo)
+{
+    int32_t status = 0;
+
+    pSpiInfo->pSpi->ctrl0 &= ~(MXC_F_SPI_CTRL0_EN);
+
+    status = MXC_SPI_Init(pSpiInfo->pSpi, pSpiInfo->master, 0, pSpiInfo->numSlaves, 0,
+                          pSpiInfo->spiSpeed);
+    // MXC_SPI_SetDataSize(pSpiInfo->pSpi, 8);
+    if (status == 0)
+    {
+        status = MXC_SPI_SetWidth(pSpiInfo->pSpi, SPI_WIDTH_STANDARD);
+    }
+    if (status == 0)
+    {
+        status = MXC_SPI_SetMode(pSpiInfo->pSpi, pSpiInfo->spiMode);
+    }
+    if (status == 0)
+    {
+        MXC_SPI_SetTXThreshold(pSpiInfo->pSpi, 4);
+        MXC_SPI_SetRXThreshold(pSpiInfo->pSpi, 0);
+    }
+
+    InitSpi(pSpiInfo->pSpi, pSpiInfo->master);
+    MXC_DMA->inten |= ((1 << pSpiInfo->txDmaDesc.channel) | (1 << pSpiInfo->rxDmaDesc.channel));
+    return status;
+}
+
+int32_t MaxStartSpiTxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    MAX_DMA_DESC *pRx = &pSpiInfo->rxDmaDesc;
+    MAX_DMA_DESC *pTx = &pSpiInfo->txDmaDesc;
+
+    pRx->pMem = (uint8_t *)&pSpiInfo->dummyCmd;
+    pRx->ctrl = (uint32_t)pRx->source | (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pRx->numBytes = numBytes;
+
+    pTx->pMem = pData;
+    pTx->ctrl = MXC_F_DMA_CTRL_SRCINC | (uint32_t)pTx->source |
+                (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pTx->numBytes = numBytes;
+
+    StartSpiDMA(pSpiInfo->pSpi, pRx, pTx, pSpiInfo->slaveIndex);
+
+    return status;
+}
+
+int32_t MaxSlaveStartSpiTxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    MAX_DMA_DESC *pRx = &pSpiInfo->rxDmaDesc;
+    MAX_DMA_DESC *pTx = &pSpiInfo->txDmaDesc;
+
+    pRx->pMem = (uint8_t *)&pSpiInfo->dummyCmd;
+    pRx->ctrl = (uint32_t)pRx->source | (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pRx->numBytes = numBytes;
+
+    pTx->pMem = pData;
+    pTx->ctrl = MXC_F_DMA_CTRL_SRCINC | (uint32_t)pTx->source |
+                (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pTx->numBytes = numBytes;
+
+    StartSpiDMA(pSpiInfo->pSpi, pRx, pTx, pSpiInfo->slaveIndex);
+
+    return status;
+}
+
+int32_t MaxStartSpiRxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    MAX_DMA_DESC *pRx = &pSpiInfo->rxDmaDesc;
+    MAX_DMA_DESC *pTx = &pSpiInfo->txDmaDesc;
+
+    pRx->pMem = pData;
+    pRx->ctrl = MXC_F_DMA_CTRL_DSTINC | (uint32_t)pRx->source |
+                (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pRx->numBytes = numBytes;
+
+    pTx->pMem = (uint8_t *)&pSpiInfo->dummyCmd;
+    pTx->ctrl = pTx->source | (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pTx->numBytes = numBytes;
+
+    StartSpiDMA(pSpiInfo->pSpi, pRx, pTx, pSpiInfo->slaveIndex);
+
+    return status;
+}
+
+int32_t MaxSlaveStartSpiRxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    MAX_DMA_DESC *pRx = &pSpiInfo->rxDmaDesc;
+    MAX_DMA_DESC *pTx = &pSpiInfo->txDmaDesc;
+
+    pRx->pMem = pData;
+    pRx->ctrl = MXC_F_DMA_CTRL_DSTINC | (uint32_t)pRx->source |
+                (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pRx->numBytes = numBytes;
+
+    pTx->pMem = (uint8_t *)&pSpiInfo->dummyCmd;
+    pTx->ctrl = pTx->source | (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pTx->numBytes = numBytes;
+
+    StartSpiDMA(pSpiInfo->pSpi, pRx, pTx, pSpiInfo->slaveIndex);
+
+    return status;
+}
+
+int32_t MaxStartSpiTxRxDMA(MAX_SPI_INSTANCE *pSpiInfo, uint8_t *pTxData, uint8_t *pRxData,
+                           uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    MAX_DMA_DESC *pRx = &pSpiInfo->rxDmaDesc;
+    MAX_DMA_DESC *pTx = &pSpiInfo->txDmaDesc;
+
+    pRx->pMem = pRxData;
+    pRx->ctrl = MXC_F_DMA_CTRL_DSTINC | (uint32_t)pRx->source |
+                (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pRx->numBytes = numBytes;
+
+    pTx->pMem = pTxData;
+    pTx->ctrl = MXC_F_DMA_CTRL_SRCINC | (uint32_t)pTx->source |
+                (MXC_DMA_WIDTH_BYTE << MXC_F_DMA_CTRL_SRCWD_POS);
+    pTx->numBytes = numBytes;
+
+    StartSpiDMA(pSpiInfo->pSpi, pRx, pTx, pSpiInfo->slaveIndex);
+
+    return status;
+}
+
+int32_t MaxSetSpiFrequency(MAX_SPI_INSTANCE *pSpiInfo, uint32_t spiFrequency)
+{
+    int32_t status = 0;
+
+    pSpiInfo->pSpi->ctrl0 &= ~(MXC_F_SPI_CTRL0_EN);
+    status = MXC_SPI_SetFrequency(pSpiInfo->pSpi, spiFrequency);
+    pSpiInfo->pSpi->ctrl0 |= MXC_F_SPI_CTRL0_EN;
+
+    return status;
+}
+
+void MaxClearSpiInterrupt(MAX_SPI_INSTANCE *pSpiInfo)
+{
+    mxc_spi_regs_t *spiInstance = (mxc_spi_regs_t *)pSpiInfo->pSpi;
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[pSpiInfo->txDmaDesc.channel].status |= 0x5C;
+    /* 0x5C is the mask for status register */
+    MXC_DMA->ch[pSpiInfo->rxDmaDesc.channel].status |= 0x5C;
+    // clear pending dma request
+    spiInstance->dma &= ~(MXC_F_SPI_DMA_DMA_TX_EN | MXC_F_SPI_DMA_DMA_RX_EN);
+}
+
+void StartSpiDMA(void *pSpi, MAX_DMA_DESC *pRx, MAX_DMA_DESC *pTx, uint32_t targetSelect)
+{
+    mxc_spi_regs_t *spiInstance = (mxc_spi_regs_t *)pSpi;
+
+    spiInstance->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+    spiInstance->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_ACTIVE;
+    spiInstance->ctrl0 |= (unsigned int)(1 << targetSelect) << MXC_F_SPI_CTRL0_SS_ACTIVE_POS;
+
+    // If the SPIn port is set to operate in 4-wire mode,
+    // SPIn_CTRL1.rx_num_chars field is ignored and the SPIn_CTRL1.tx_num_chars
+    // field is used for both the number of characters to receive and transmit.
+    spiInstance->ctrl1 = (pTx->numBytes & MXC_F_SPI_CTRL1_TX_NUM_CHAR)
+                         << MXC_F_SPI_CTRL1_TX_NUM_CHAR_POS;
+    // flush tx and rx fifo
+    spiInstance->dma |= (MXC_F_SPI_DMA_TX_FLUSH | MXC_F_SPI_DMA_RX_FLUSH);
+    // Any pending DMA requests are cleared
+    spiInstance->dma &= ~(MXC_F_SPI_DMA_DMA_TX_EN | MXC_F_SPI_DMA_DMA_RX_EN);
+
+    MaxEnableDMAChannel(pRx);
+    MaxEnableDMAChannel(pTx);
+
+    spiInstance->dma |= (MXC_F_SPI_DMA_DMA_TX_EN | MXC_F_SPI_DMA_DMA_RX_EN);
+    // start the spi Transaction
+    spiInstance->ctrl0 |= MXC_F_SPI_CTRL0_START;
+}
+
+void InitSpi(void *pSpi, uint32_t master)
+{
+
+    mxc_spi_regs_t *spiInstance = (mxc_spi_regs_t *)pSpi;
+    if (master == 1)
+    {
+        spiInstance->inten |= MXC_F_SPI_INTEN_TX_OV | MXC_F_SPI_INTEN_RX_OV;
+    }
+    else
+    {
+        spiInstance->inten |= MXC_F_SPI_INTEN_SSD;
+    }
+    spiInstance->ctrl0 &= ~MXC_F_SPI_CTRL0_EN;
+    spiInstance->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+
+    // flush tx and rx fifo
+    spiInstance->dma |= (MXC_F_SPI_DMA_TX_FLUSH | MXC_F_SPI_DMA_RX_FLUSH);
+    // Any pending DMA requests are cleared
+    spiInstance->dma &= ~(MXC_F_SPI_DMA_DMA_TX_EN | MXC_F_SPI_DMA_DMA_RX_EN);
+    spiInstance->dma |= (MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN);
+
+    spiInstance->ctrl0 &= ~MXC_F_SPI_CTRL0_MST_MODE;
+    spiInstance->ctrl0 |= ((uint32_t)(master << MXC_F_SPI_CTRL0_MST_MODE_POS));
+
+    spiInstance->ctrl0 |= MXC_F_SPI_CTRL0_EN;
+    spiInstance->intfl = MXC_F_SPI_INTFL_MST_DONE;
+}
+
+/**
+ * @}
+ */

--- a/max/source/max3267x_timer_config.c
+++ b/max/source/max3267x_timer_config.c
@@ -1,0 +1,140 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     max3267x_timer_config.c
+ * @brief    Timer configuration
+ * @{
+ */
+/*============= I N C L U D E S =============*/
+
+#include "max3267x_timer_config.h"
+#include "app_cfg.h"
+#include "mxc_device.h"
+#include "nvic_table.h"
+#include "tmr.h"
+#include "tmr_revb.h"
+#include <stdint.h>
+
+/*=============  D E F I N I T I O N S  =============*/
+#if APP_CFG_SYSTEM_TIMER_CLOCK_TYPE == 1
+/** timer clock */
+#define ADE_TIMER_CLOCK MXC_TMR_8M_CLK
+/** timer clock source*/
+#define ADE_TIMER_CLOCK_SOURCE MXC_TMR_CLK2
+/** count for convert timer count to us */
+#define TIMER_COUNT_US 7.3728f // 8 for 8Mhz and 50 for 50Mhz
+#else
+/** timer clock */
+#define ADE_TIMER_CLOCK        MXC_TMR_APB_CLK
+/** timer clock source*/
+#define ADE_TIMER_CLOCK_SOURCE MXC_TMR_CLK0
+/** count for convert timer count to us */
+#define TIMER_COUNT_US         50.0f // 8 for 8Mhz and 50 for 50Mhz
+#endif
+
+/**
+ * @brief  Pulse 1 Timer interrupt handler.
+ *
+ */
+static void TimerHandler(void);
+
+/**
+ * Read timer counter
+ */
+static inline unsigned int ReadTimerCountRegister(mxc_tmr_regs_t *pTmr);
+
+/** timer registers */
+static mxc_tmr_regs_t *pSysTmr;
+/**  Define the timer width (16-bit or 32-bit) */
+#define TIMER_WIDTH 32 // Change to 16 for 16-bit timers
+
+/*=============  C O D E  =============*/
+int32_t MaxTimerInit(mxc_tmr_regs_t *pTmr)
+{
+    IRQn_Type irqn;
+    int32_t status;
+    mxc_tmr_cfg_t config;
+    MXC_TMR_Shutdown(pTmr);
+
+    config.pres = TMR_PRES_1;
+    config.mode = TMR_MODE_CONTINUOUS;
+    config.clock = ADE_TIMER_CLOCK;
+    config.cmp_cnt = 0xffffffff;
+    config.pol = 0;
+    config.bitMode = TMR_BIT_MODE_32;
+
+    irqn = MXC_TMR_GET_IRQ(MXC_TMR_GET_IDX(pTmr));
+    pSysTmr = pTmr;
+
+    NVIC_SetVector(irqn, (uint32_t)TimerHandler);
+    NVIC_EnableIRQ(irqn);
+    status = MXC_TMR_Init(pTmr, &config, false);
+    pTmr->ctrl1 |= (ADE_TIMER_CLOCK_SOURCE << MXC_F_TMR_REVB_CTRL1_CLKSEL_B_POS);
+    MXC_TMR_EnableInt(pTmr);
+
+    return status;
+}
+
+uint32_t MaxGetTime(mxc_tmr_regs_t *pTmr)
+{
+    uint32_t timerCnt = ReadTimerCountRegister(pTmr);
+    return (uint32_t)(((float)timerCnt / TIMER_COUNT_US));
+}
+
+uint32_t MaxGetMaximumTime()
+{
+    uint32_t timerCnt = (uint32_t)((1ULL << TIMER_WIDTH) - 1);
+    return (uint32_t)(((float)timerCnt / TIMER_COUNT_US));
+}
+
+void MaxStartTimer(mxc_tmr_regs_t *pTmr)
+{
+    MXC_TMR_ClearFlags(pTmr);
+    pTmr->cnt = 0x01;
+    MXC_TMR_Start(pTmr);
+}
+
+void MaxStopTimer(mxc_tmr_regs_t *pTmr)
+{
+    MXC_TMR_Stop(pTmr);
+}
+
+static void TimerHandler(void)
+{
+    MXC_TMR_ClearFlags(pSysTmr);
+}
+
+static inline unsigned int ReadTimerCountRegister(mxc_tmr_regs_t *pTmr)
+{
+#if APP_CFG_SYSTEM_TIMER_CLOCK_TYPE == 1
+    uint32_t cnt;
+    uint32_t cnt0;
+    uint32_t cnt1;
+    uint32_t cnt2;
+    uint32_t diff20;
+    uint32_t diff21;
+    uint32_t isCnt2Good;
+    uint32_t isCnt1Good;
+    cnt0 = pTmr->cnt;
+    cnt1 = pTmr->cnt;
+    cnt2 = pTmr->cnt;
+    diff21 = cnt2 - cnt1;
+    diff20 = cnt2 - cnt0;
+    /* We make an assumption that only one out of 3 consecutive read will be wrong
+        So either cnt2 or cnt1 is correct. If both are correct we will use cnt2
+     */
+    /* Unsigned numbers  - only diff of 0, 1 meets the criteria*/
+    isCnt2Good = (diff20 <= 1) || (diff21 <= 1);
+    isCnt1Good = !isCnt2Good;
+    cnt = isCnt2Good * cnt2 + isCnt1Good * cnt1;
+    return cnt;
+#else
+    return pTmr->cnt;
+#endif
+}
+
+/**
+ * @}
+ */

--- a/max/source/max3267x_uart_config.c
+++ b/max/source/max3267x_uart_config.c
@@ -1,0 +1,138 @@
+/******************************************************************************
+ Copyright (c) 2024 - 2025  Analog Devices Inc.
+******************************************************************************/
+
+/**
+ * @file     max3267x_uart_config.c
+ * @brief    UART communication configuration
+ *           in MAX32670
+ * @{
+ */
+
+/*=============  I N C L U D E S   =============*/
+#include "max3267x_uart_config.h"
+#include "dma.h"
+#include "mxc_device.h"
+#include "nvic_table.h"
+#include "uart.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/*============= D A T A T Y P E S ===========*/
+
+/*============= P R O T O T Y P E S =============*/
+
+/*=============  D A T A  =============*/
+/** uart request */
+static mxc_uart_req_t readReq;
+/** DMA configuration */
+static mxc_dma_config_t config;
+/** DMA source/destination */
+mxc_dma_srcdst_t srcdst;
+
+/*=============  C O D E  =============*/
+
+/**
+ * @brief Serial communication initialization function.
+ * @return 0 -  Success, <0 = Failed to initialize
+ */
+int32_t MaxInitUart(MAX_UART_INSTANCE *pUartInfo)
+{
+    int32_t status = 0;
+
+    status = MXC_UART_Init(pUartInfo->pUart, pUartInfo->baudrate, MXC_UART_APB_CLK);
+    if (status == 0)
+    {
+        MXC_DMA->inten |=
+            ((1 << pUartInfo->txDmaDesc.channel) | (1 << pUartInfo->rxDmaDesc.channel));
+    }
+
+    return status;
+}
+
+int32_t MaxStartUartRx(MAX_UART_INSTANCE *pUartInfo, uint8_t *pData, uint32_t length)
+{
+    int32_t status;
+    mxc_uart_req_t *pReadReq = &readReq;
+
+    pReadReq->uart = pUartInfo->pUart;
+    pReadReq->rxData = pData;
+    pReadReq->rxLen = length;
+    pReadReq->txLen = 0;
+    pReadReq->txData = NULL;
+    pReadReq->callback = pUartInfo->pfRxCallback;
+
+    status = MXC_UART_TransactionAsync(pReadReq);
+
+    return status;
+}
+
+int32_t MaxStartUartTxDMA(MAX_UART_INSTANCE *pUartInfo, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    srcdst.ch = pUartInfo->txDmaDesc.channel;
+    srcdst.source = pData;
+    srcdst.dest = NULL;
+    srcdst.len = numBytes;
+
+    config.ch = pUartInfo->txDmaDesc.channel;
+    config.reqsel = pUartInfo->txDmaDesc.source;
+    config.srcwd = MXC_DMA_WIDTH_BYTE;
+    config.srcinc_en = 1;
+    config.dstinc_en = 0;
+
+    MXC_DMA_ConfigChannel(config, srcdst);
+    MXC_DMA_SetSrcDst(srcdst);
+    MXC_DMA_SetChannelInterruptEn(pUartInfo->txDmaDesc.channel, true, true);
+
+    // Enable the Tx DMA and set the DMA Tx thd.
+    pUartInfo->pUart->dma |= MXC_F_UART_DMA_TX_EN;
+    pUartInfo->pUart->dma |= (2 << MXC_F_UART_DMA_TX_THD_VAL_POS);
+
+    MXC_DMA_Start(pUartInfo->txDmaDesc.channel);
+
+    return status;
+}
+int32_t MaxStartUartRxDMA(MAX_UART_INSTANCE *pUartInfo, uint8_t *pData, uint32_t numBytes)
+{
+    int32_t status = 0;
+
+    srcdst.ch = pUartInfo->rxDmaDesc.channel;
+    srcdst.source = NULL;
+    srcdst.dest = pData;
+    srcdst.len = numBytes;
+
+    config.ch = pUartInfo->rxDmaDesc.channel;
+    config.reqsel = pUartInfo->rxDmaDesc.source;
+    config.srcwd = MXC_DMA_WIDTH_BYTE;
+    config.srcinc_en = 0;
+    config.dstinc_en = 1;
+
+    MXC_DMA_ConfigChannel(config, srcdst);
+    MXC_DMA_SetSrcDst(srcdst);
+    MXC_DMA_EnableInt(pUartInfo->rxDmaDesc.channel);
+    MXC_DMA_SetChannelInterruptEn(pUartInfo->rxDmaDesc.channel, true, true);
+
+    // Enable the Rx DMA and set the DMA Rx thd.
+    pUartInfo->pUart->dma |= MXC_F_UART_DMA_RX_EN;
+    pUartInfo->pUart->dma |= (1 << MXC_F_UART_DMA_RX_THD_VAL_POS);
+
+    MXC_DMA_Start(pUartInfo->rxDmaDesc.channel);
+
+    return status;
+}
+
+int32_t MaxSetUartBaudrate(MAX_UART_INSTANCE *pUartInfo, uint32_t baudRate)
+{
+    int32_t status = 0;
+    MXC_UART_SetFrequency(pUartInfo->pUart, baudRate, MXC_UART_APB_CLK);
+    // Flush the Rx Data that's pending after changing the baudrate
+    pUartInfo->pUart->ctrl |= MXC_F_UART_CTRL_RX_FLUSH;
+    return status;
+}
+
+/**
+ * @}
+ */


### PR DESCRIPTION
Added support for [ADE9178 Evaluation Board](https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ade9178.html)